### PR TITLE
Support Raw Message Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Docker Pulls](https://img.shields.io/docker/pulls/jameskbride/local-sns.svg?maxAge=2592000)](https://hub.docker.com/r/jameskbride/localsns/)
+
 # Local SNS
 Fake Amazon Simple Notification Service (SNS) for local development. Supports:
 - Create/List/Delete topics

--- a/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
@@ -17,7 +17,11 @@ data class Subscription(
     val arnPattern = """([\w+_:-]{1,512})"""
   }
 
-  fun decodedEndpointUrl():String {
+  @JsonIgnore fun decodedEndpointUrl():String {
     return URLDecoder.decode(endpoint, "UTF-8")
+  }
+
+  @JsonIgnore fun isRawMessageDelivery(): Boolean {
+    return subscriptionAttributes.getOrDefault("RawMessageDelivery", "false") == "true"
   }
 }

--- a/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
@@ -2,6 +2,7 @@ package com.jameskbride.localsns.models
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.io.Serializable
+import java.net.URLDecoder
 
 data class Subscription(
   val arn: String,
@@ -14,5 +15,9 @@ data class Subscription(
   companion object {
     val namePattern = """([\w+_-]{1,256})"""
     val arnPattern = """([\w+_:-]{1,512})"""
+  }
+
+  fun decodedEndpointUrl():String {
+    return URLDecoder.decode(endpoint, "UTF-8")
   }
 }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -178,16 +178,22 @@ private fun publishMessage(
             publishToSqs(subscription, message, headers, producer, logger)
         }
         else -> {
-            val timestamp = LocalDateTime.now()
-            val snsMessage = createSnsMessage(subscription, message, timestamp)
-            val gson = Gson()
-            val messageToPublish = gson.toJson(snsMessage)
-            publish(subscription, messageToPublish, headers, producer, logger)
+            publishAllowingRawMessage(subscription, message, headers, producer, logger)
         }
     }
 }
 
 private fun publishToSqs(
+    subscription: Subscription,
+    message: String,
+    headers: Map<String, String>,
+    producer: ProducerTemplate,
+    logger: Logger
+) {
+    publishAllowingRawMessage(subscription, message, headers, producer, logger)
+}
+
+private fun publishAllowingRawMessage(
     subscription: Subscription,
     message: String,
     headers: Map<String, String>,
@@ -202,7 +208,6 @@ private fun publishToSqs(
         val gson = Gson()
         gson.toJson(snsMessage)
     }
-
     publish(subscription, messageToPublish, headers, producer, logger)
 }
 

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -168,6 +168,9 @@ private fun publishMessage(
         "http" -> {
             publishToHttp(subscription, headers, message, producer, logger)
         }
+        "https" -> {
+            publishToHttp(subscription, headers, message, producer, logger)
+        }
         else -> {
             val timestamp = LocalDateTime.now()
             val snsMessage = createSnsMessage(timestamp, message, subscription)

--- a/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
@@ -26,7 +26,7 @@ open class BaseTest {
     protected fun createValidArn(resourceName: String) =
         "arn:aws:sns:us-east-1:123456789012:${resourceName}"
 
-    fun createEndpoint(name: String): String {
+    fun createSqsEndpoint(name: String): String {
         return "aws2-sqs://$name?accessKey=xxx&secretKey=xxx&region=us-east-1&trustAllCertificates=true&overrideEndpoint=true&uriEndpointOverride=http://localhost:9324/000000000000/$name&messageAttributeNames=first,second"
     }
 

--- a/src/test/kotlin/com/jameskbride/localsns/DatabaseVerticleTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/DatabaseVerticleTest.kt
@@ -40,7 +40,7 @@ class DatabaseVerticleTest: BaseTest() {
             arn = createValidArn("subscription1"),
             owner="owner",
             protocol="sqs",
-            endpoint=createEndpoint("queue1")
+            endpoint=createSqsEndpoint("queue1")
         )
 
         val topics = getTopicsMap(vertx)!!

--- a/src/test/kotlin/com/jameskbride/localsns/GetSubscriptionAttributesRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/GetSubscriptionAttributesRouteTest.kt
@@ -38,7 +38,7 @@ class GetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it returns an error when SubscriptionArn is invalid`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        subscribe(topicArn = topic.arn, createEndpoint("queue1"), "sqs")
+        subscribe(topicArn = topic.arn, createSqsEndpoint("queue1"), "sqs")
         val response = getSubscriptionAttributes("bad arn")
 
         assertEquals(400, response.statusCode)
@@ -48,7 +48,7 @@ class GetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it can return default attribute values`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val endpoint = createEndpoint("queue1")
+        val endpoint = createSqsEndpoint("queue1")
         val subscriptionArn = getSubscriptionArnFromResponse((subscribe(topicArn = topic.arn, endpoint, "sqs")))
 
         val response = getSubscriptionAttributes(subscriptionArn)
@@ -73,7 +73,7 @@ class GetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it can return overridden attributes`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val endpoint = createEndpoint("queue1")
+        val endpoint = createSqsEndpoint("queue1")
         val subscriptionArn = getSubscriptionArnFromResponse((subscribe(topicArn = topic.arn, endpoint, "sqs")))
 
         setSubscriptionAttributes(subscriptionArn, "RawMessageDelivery", "true")
@@ -90,7 +90,7 @@ class GetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it can return arbitrary attributes`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val endpoint = createEndpoint("queue1")
+        val endpoint = createSqsEndpoint("queue1")
         val subscriptionArn = getSubscriptionArnFromResponse((subscribe(topicArn = topic.arn, endpoint, "sqs")))
 
         setSubscriptionAttributes(subscriptionArn, "status", "sending")

--- a/src/test/kotlin/com/jameskbride/localsns/ListSubscriptionsByTopicRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/ListSubscriptionsByTopicRouteTest.kt
@@ -61,12 +61,12 @@ class ListSubscriptionsByTopicRouteTest: BaseTest() {
     @Test
     fun `it returns success when there are subscriptions for a topic`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val endpoint1 = createEndpoint("queue1")
+        val endpoint1 = createSqsEndpoint("queue1")
         val subscribeResponse1 = subscribe(topic.arn, endpoint1, "sqs")
         val subscription1Arn = getSubscriptionArnFromResponse(subscribeResponse1)
 
         val topic2 = createTopicModel("topic2")
-        val endpoint2 = createEndpoint("queue2")
+        val endpoint2 = createSqsEndpoint("queue2")
         val subscribeResponse2 = subscribe(topic2.arn, endpoint2, "lambda")
         val subscription2Arn = getSubscriptionArnFromResponse(subscribeResponse2)
 

--- a/src/test/kotlin/com/jameskbride/localsns/ListSubscriptionsRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/ListSubscriptionsRouteTest.kt
@@ -29,12 +29,12 @@ class ListSubscriptionsRouteTest: BaseTest() {
     @Test
     fun `it returns subscriptions when they exist `(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val endpoint1 = createEndpoint("queue1")
+        val endpoint1 = createSqsEndpoint("queue1")
         val subscribeResponse1 = subscribe(topic.arn, endpoint1, "sqs")
         val subscription1Arn = getSubscriptionArnFromResponse(subscribeResponse1)
 
         val topic2 = createTopicModel("topic2")
-        val endpoint2 = createEndpoint("queue2")
+        val endpoint2 = createSqsEndpoint("queue2")
         val subscribeResponse2 = subscribe(topic2.arn, endpoint2, "lambda")
         val subscription2Arn = getSubscriptionArnFromResponse(subscribeResponse2)
 

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -103,7 +103,7 @@ class PublishRouteIntegrationTest: BaseTest() {
         val topic = createTopicModel("topic1")
         val queueName = "standard-publish"
         createQueue(queueName)
-        subscribe(topic.arn, createEndpoint(queueName), "sqs")
+        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs")
         val message = "Hello, SNS!"
 
         val queueUrl = createQueueUrl(queueName)
@@ -129,7 +129,7 @@ class PublishRouteIntegrationTest: BaseTest() {
         val topic = createTopicModel("topic1")
         val queueName = "raw-queue"
         createQueue(queueName)
-        subscribe(topic.arn, createEndpoint(queueName), "sqs", mapOf("RawMessageDelivery" to "true"))
+        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs", mapOf("RawMessageDelivery" to "true"))
         val message = "Hello, SNS!"
 
         val queueUrl = createQueueUrl(queueName)
@@ -153,7 +153,7 @@ class PublishRouteIntegrationTest: BaseTest() {
         val topic = createTopicModel("topic1")
         val queueName = "target-arn-queue"
         createQueue(queueName)
-        subscribe(topic.arn, createEndpoint(queueName), "sqs")
+        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs")
         val message = "Hello, SNS!"
         val request = publishRequest(topic, message, useTargetArn = true)
 
@@ -178,7 +178,7 @@ class PublishRouteIntegrationTest: BaseTest() {
         val topic = createTopicModel("topic1")
         val queueName = "with-attributes"
         createQueue(queueName)
-        subscribe(topic.arn, createEndpoint(queueName), "sqs")
+        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs")
         val message = "Hello, SNS!"
         val messageAttributes = mapOf(
             "first" to "firstValue",

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -102,8 +102,8 @@ class PublishRouteIntegrationTest: BaseTest() {
     fun `it can publish messages to sqs`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val queueName = "standard-publish"
-        createQueue(queueName)
-        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs")
+        val endpoint = createQueue(queueName)
+        subscribe(topic.arn, endpoint, "sqs")
         val message = "Hello, SNS!"
 
         val queueUrl = createQueueUrl(queueName)
@@ -128,8 +128,8 @@ class PublishRouteIntegrationTest: BaseTest() {
     fun `it can publish raw messages to sqs`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val queueName = "raw-queue"
-        createQueue(queueName)
-        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs", mapOf("RawMessageDelivery" to "true"))
+        val endpoint = createQueue(queueName)
+        subscribe(topic.arn, endpoint, "sqs", mapOf("RawMessageDelivery" to "true"))
         val message = "Hello, SNS!"
 
         val queueUrl = createQueueUrl(queueName)
@@ -153,7 +153,8 @@ class PublishRouteIntegrationTest: BaseTest() {
         val topic = createTopicModel("topic1")
         val queueName = "target-arn-queue"
         createQueue(queueName)
-        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs")
+        val endpoint = createSqsEndpoint(queueName)
+        subscribe(topic.arn, endpoint, "sqs")
         val message = "Hello, SNS!"
         val request = publishRequest(topic, message, useTargetArn = true)
 
@@ -177,8 +178,8 @@ class PublishRouteIntegrationTest: BaseTest() {
     fun `it can publish with message attributes`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val queueName = "with-attributes"
-        createQueue(queueName)
-        subscribe(topic.arn, createSqsEndpoint(queueName), "sqs")
+        val endpoint = createQueue(queueName)
+        subscribe(topic.arn, endpoint, "sqs")
         val message = "Hello, SNS!"
         val messageAttributes = mapOf(
             "first" to "firstValue",
@@ -208,11 +209,13 @@ class PublishRouteIntegrationTest: BaseTest() {
         }
     }
 
-    private fun createQueue(queueName: String) {
+    private fun createQueue(queueName: String): String {
         sqsSyncClient.createQueue {
             it.queueName(queueName)
             it.build()
         }
+
+        return createSqsEndpoint(queueName)
     }
 
     @Test

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteTest.kt
@@ -49,7 +49,7 @@ class PublishRouteTest: BaseTest() {
     @Test
     fun `it returns an error when MessageStructure is not json`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        subscribe(topic.arn, createEndpoint("queue2"), "sqs")
+        subscribe(topic.arn, createSqsEndpoint("queue2"), "sqs")
         val message = "Hello, SNS!"
 
         val response = publish(topic.arn, message, messageStructure = "wrongValue")
@@ -61,7 +61,7 @@ class PublishRouteTest: BaseTest() {
     @Test
     fun `it returns an error when MessageStructure is valid and Message is not JSON`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        subscribe(topic.arn, createEndpoint("queue2"), "sqs")
+        subscribe(topic.arn, createSqsEndpoint("queue2"), "sqs")
         val message = "Hello, SNS!"
 
         val response = publish(topic.arn, message, messageStructure = "json")
@@ -73,7 +73,7 @@ class PublishRouteTest: BaseTest() {
     @Test
     fun `it returns an error when MessageStructure is valid and Message does not contain a default key`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        subscribe(topic.arn, createEndpoint("queue2"), "sqs")
+        subscribe(topic.arn, createSqsEndpoint("queue2"), "sqs")
         data class BadMessage(val http:String): Serializable
         val badMessage = BadMessage(http = "some message")
         val message = Json.encode(badMessage)

--- a/src/test/kotlin/com/jameskbride/localsns/SetSubscriptionAttributesRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/SetSubscriptionAttributesRouteTest.kt
@@ -28,7 +28,7 @@ class SetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it returns an error when AttributeName is missing`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createEndpoint("queue1"), "sqs"))
+        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs"))
 
         val response = setSubscriptionAttributes(subscriptionArn, null, "value")
 
@@ -40,7 +40,7 @@ class SetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it returns an error when AttributeValue is missing`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createEndpoint("queue1"), "sqs"))
+        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs"))
 
         val response = setSubscriptionAttributes(subscriptionArn, attributeName = null, "name")
 
@@ -61,7 +61,7 @@ class SetSubscriptionAttributesRouteTest: BaseTest() {
     @Test
     fun `it returns success when the message attribute is set`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createEndpoint("queue1"), "sqs"))
+        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs"))
 
         val response = setSubscriptionAttributes(subscriptionArn, "name", "value")
 

--- a/src/test/kotlin/com/jameskbride/localsns/SubscribeRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/SubscribeRouteTest.kt
@@ -20,7 +20,7 @@ class SubscribeRouteTest : BaseTest() {
 
     @Test
     fun `it returns an error when the topic arn is missing`(testContext: VertxTestContext) {
-        val response = subscribe(null, createEndpoint("queue1"), "sqs")
+        val response = subscribe(null, createSqsEndpoint("queue1"), "sqs")
         assertEquals(400, response.statusCode)
 
         testContext.completeNow()
@@ -31,7 +31,7 @@ class SubscribeRouteTest : BaseTest() {
         val topic = "topic1"
         val topicResponse = createTopic(topic)
         val topicArn = getTopicArnFromResponse(topicResponse)
-        val response = subscribe(topicArn, createEndpoint("queue1"), null)
+        val response = subscribe(topicArn, createSqsEndpoint("queue1"), null)
         assertEquals(400, response.statusCode)
 
         testContext.completeNow()
@@ -40,7 +40,7 @@ class SubscribeRouteTest : BaseTest() {
     @Test
     fun `it returns an error when topic arn is invalid`(testContext: VertxTestContext) {
         val topic = "bad topic"
-        val response = subscribe(topic, createEndpoint("queue1"), "sqs")
+        val response = subscribe(topic, createSqsEndpoint("queue1"), "sqs")
         assertEquals(400, response.statusCode)
 
         testContext.completeNow()
@@ -50,7 +50,7 @@ class SubscribeRouteTest : BaseTest() {
     fun `it returns an error when topic arn does not exist`(testContext: VertxTestContext) {
         val topic = "topic1"
         createTopic(topic)
-        val response = subscribe(createValidArn("doesnotexist"), createEndpoint("queue1"), "sqs")
+        val response = subscribe(createValidArn("doesnotexist"), createSqsEndpoint("queue1"), "sqs")
         assertEquals(400, response.statusCode)
 
         testContext.completeNow()
@@ -60,7 +60,7 @@ class SubscribeRouteTest : BaseTest() {
     fun `it can subscribe to a topic`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
 
-        val response = subscribe(topic.arn, createEndpoint("queue1"), "sqs")
+        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs")
 
         val subscriptionArn = getSubscriptionArnFromResponse(response)
         assertEquals(200, response.statusCode)
@@ -77,7 +77,7 @@ class SubscribeRouteTest : BaseTest() {
             testContext.completeNow()
         }
 
-        subscribe(topic.arn, createEndpoint("queue1"), "sqs")
+        subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs")
     }
 
     @Test
@@ -87,7 +87,7 @@ class SubscribeRouteTest : BaseTest() {
         )
         val topic = createTopicModel("topic1")
 
-        val response = subscribe(topic.arn, createEndpoint("queue1"), "sqs", messageAttributes)
+        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs", messageAttributes)
         val subscriptionArn = getSubscriptionArnFromResponse(response)
         assertEquals(200, response.statusCode)
         assertTrue(subscriptionArn.isNotEmpty())

--- a/src/test/kotlin/com/jameskbride/localsns/UnsubscribeRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/UnsubscribeRouteTest.kt
@@ -39,7 +39,7 @@ class UnsubscribeRouteTest: BaseTest() {
     @Test
     fun `it returns an error when subscription arn is invalid`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        subscribe(topic.arn, createEndpoint("endpoint"), "sqs")
+        subscribe(topic.arn, createSqsEndpoint("endpoint"), "sqs")
 
         val response = unsubscribe("bad arn")
 
@@ -51,7 +51,7 @@ class UnsubscribeRouteTest: BaseTest() {
     @Test
     fun `it returns an success when subscription exists`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val subscriptionResponse = subscribe(topic.arn, createEndpoint("endpoint"), "sqs")
+        val subscriptionResponse = subscribe(topic.arn, createSqsEndpoint("endpoint"), "sqs")
         val subscriptionArn = getSubscriptionArnFromResponse(subscriptionResponse)
 
         val response = unsubscribe(subscriptionArn)
@@ -75,7 +75,7 @@ class UnsubscribeRouteTest: BaseTest() {
     @Test
     fun `it indicates a db change`(vertx: Vertx, testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
-        val subscriptionResponse = subscribe(topic.arn, createEndpoint("endpoint"), "sqs")
+        val subscriptionResponse = subscribe(topic.arn, createSqsEndpoint("endpoint"), "sqs")
         val subscriptionArn = getSubscriptionArnFromResponse(subscriptionResponse)
 
         vertx.eventBus().consumer<String>("configChange") {

--- a/src/test/resources/elasticmq.conf
+++ b/src/test/resources/elasticmq.conf
@@ -15,33 +15,6 @@ rest-sqs {
 }
 
 queues {
-  queue1 {
-    defaultVisibilityTimeout = 10 seconds
-    delay = 5 seconds
-    receiveMessageWait = 0 seconds
-    deadLettersQueue {
-      name = "queue1-dead-letter"
-      maxReceiveCount = 3 // from 1 to 1000
-    }
-    fifo = false
-    contentBasedDeduplication = false
-  }
-  queue1-dead-letter { }
-}
-
-queues {
-  queue2 {
-    defaultVisibilityTimeout = 10 seconds
-    delay = 5 seconds
-    receiveMessageWait = 0 seconds
-    deadLettersQueue {
-      name = "queue1-dead-letter"
-      maxReceiveCount = 3 // from 1 to 1000
-    }
-    fifo = false
-    contentBasedDeduplication = false
-  }
-  queue2-dead-letter { }
 }
 
 # Region and accountId which will be included in resource ids


### PR DESCRIPTION
# Context
Addresses #4. http(s) and sqs should support subscriptions with the `RawMessageDelivery` attribute set to `"true"`, allowing the message paylod to be delivered without the SNS metadata wrapping it. This also fixes Slack to always send the raw message as it doesn't support the SNS Message format.  

# Changes
- Slack always publishes the raw message.
- It can publish raw messages to sqs.
- Can publish to http with raw message delivery.
- https handles raw message delivery.
- It can publish raw http messages with MessageStructure.
- It can publish raw sqs messages with MessageStructure.
- Adding a docker pull badge to the README.

# Testing and Validation Steps
## HTTP(S)
1. Create a subscription with an http endpoint and the `RawMessageDelivery` attribute.
2. Publish a message to the subscription topic.
3. Validate that the message is received by the endpoint with the SNS metadata included.
4. Add the `RawMessageDelivery` attribute via `SetSubscriptionAttribute`.
5. Publish a message to the topic.
6. Validate that the raw message payload is delivered without the SNS metadata.
7. Publish a message using the `MessageStructure` attribute (set to `json`) with an entry in the payload for `http`.
8. Validate that the raw message payload is delivered without the SNS metadata.

## SQS
1.Create a new SQS queue. 
2. Create a subscription with the sqs endpoint and the `RawMessageDelivery` attribute.
3. Publish a message to the subscription topic.
4. Validate that the message is received by the endpoint with the SNS metadata included.
5. Add the `RawMessageDelivery` attribute via `SetSubscriptionAttribute`.
6. Publish a message to the topic.
7. Validate that the raw message payload is delivered without the SNS metadata.
8. Publish a message using the `MessageStructure` attribute (set to `json`) with an entry in the payload for `sqs`.
9. Validate that the raw message payload is delivered without the SNS metadata.

## Slack
1. Create a subscription with a slack endpoint without the `RawMessageDelivery` attribute.
2. Publish a message to the subscription topic.
3. Validate that the raw message is received by Slack.

