### PR TITLE
Persist Subscription Attributes

### DIFF
--- a/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
@@ -6,7 +6,7 @@ private const val ATTRIBUTE_PATTERN = ".*Attributes\\.entry\\.(\\d+)\\.(.*?)"
 
 data class MessageAttribute(val name:String, val value:String): Serializable {
     companion object {
-        fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): List<MessageAttribute> {
+        fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, MessageAttribute> {
             val pattern = ATTRIBUTE_PATTERN.toRegex()
             val entryNumbers = attributes.map { attribute ->
                 val match = pattern.matchEntire(attribute.key)
@@ -24,8 +24,8 @@ data class MessageAttribute(val name:String, val value:String): Serializable {
                     it.key.matches(namePattern.toRegex())
                 }!!.value
 
-                MessageAttribute(name, value)
-            }
+                mapOf(name to MessageAttribute(name, value))
+            }.fold(mapOf<String, MessageAttribute>()) { acc, map -> acc + map }
 
             return messageAttributes
         }

--- a/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
@@ -13,7 +13,6 @@ data class Subscription(
   val subscriptionAttributes: Map<String, String> = mapOf()
 ): Serializable {
   companion object {
-    val namePattern = """([\w+_-]{1,256})"""
     val arnPattern = """([\w+_:-]{1,512})"""
   }
 

--- a/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
@@ -10,7 +10,7 @@ data class Subscription(
   val topicArn: String,
   val protocol: String,
   val endpoint: String?,
-  @JsonIgnore val subscriptionAttributes: Map<String, String> = mapOf()
+  val subscriptionAttributes: Map<String, String> = mapOf()
 ): Serializable {
   companion object {
     val namePattern = """([\w+_-]{1,256})"""

--- a/src/main/kotlin/com/jameskbride/localsns/models/SubscriptionAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/SubscriptionAttribute.kt
@@ -1,0 +1,31 @@
+package com.jameskbride.localsns.models
+
+private const val SUBSCRIPTION_ATTRIBUTE_PATTERN = ".*Attributes\\.entry\\.(\\d+)\\.(.*?)"
+
+data class SubscriptionAttribute(val name:String, val value:String) {
+    companion object {
+        fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, SubscriptionAttribute> {
+            val pattern = SUBSCRIPTION_ATTRIBUTE_PATTERN.toRegex()
+            val entryNumbers = attributes.map { attribute ->
+                val match = pattern.matchEntire(attribute.key)
+                match!!.groupValues[1].toInt()
+            }.distinct()
+
+            val subscriptionAttributes = entryNumbers.map { entryNumber ->
+                val name = attributes.find {
+                    val namePattern = ".*Attributes\\.entry\\.$entryNumber.key"
+                    it.key.matches(namePattern.toRegex())
+                }!!.value
+
+                val value = attributes.find {
+                    val namePattern = ".*Attributes\\.entry\\.$entryNumber.value"
+                    it.key.matches(namePattern.toRegex())
+                }!!.value
+
+                mapOf(name to SubscriptionAttribute(name, value))
+            }.fold(mapOf<String, SubscriptionAttribute>()) { acc, map -> acc + map }
+
+            return subscriptionAttributes
+        }
+    }
+}

--- a/src/main/kotlin/com/jameskbride/localsns/models/SubscriptionAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/SubscriptionAttribute.kt
@@ -4,7 +4,7 @@ private const val SUBSCRIPTION_ATTRIBUTE_PATTERN = ".*Attributes\\.entry\\.(\\d+
 
 data class SubscriptionAttribute(val name:String, val value:String) {
     companion object {
-        fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, SubscriptionAttribute> {
+        fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, String> {
             val pattern = SUBSCRIPTION_ATTRIBUTE_PATTERN.toRegex()
             val entryNumbers = attributes.map { attribute ->
                 val match = pattern.matchEntire(attribute.key)
@@ -22,8 +22,8 @@ data class SubscriptionAttribute(val name:String, val value:String) {
                     it.key.matches(namePattern.toRegex())
                 }!!.value
 
-                mapOf(name to SubscriptionAttribute(name, value))
-            }.fold(mapOf<String, SubscriptionAttribute>()) { acc, map -> acc + map }
+                mapOf(name to value)
+            }.fold(mapOf<String, String>()) { acc, map -> acc + map }
 
             return subscriptionAttributes
         }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/routes.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/routes.kt
@@ -33,6 +33,7 @@ val getRoute: (RoutingContext) -> Unit = { ctx: RoutingContext ->
         route(ctx)
     } catch(ex: Exception) {
         logger.error(ex)
+        ex.printStackTrace()
         logAndReturnError(ctx, logger, ex.message ?: INTERNAL_ERROR, INTERNAL_ERROR, 500)
     }
 }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/setSubscriptionAttributesRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/setSubscriptionAttributesRoute.kt
@@ -34,6 +34,15 @@ val setSubscriptionAttributesRoute: (RoutingContext) -> Unit = route@{ ctx: Rout
         return@route
     }
 
+    if (attributeName == "RawMessageDelivery" && !listOf("true", "false").contains(attributeValue)) {
+        logAndReturnError(
+            ctx,
+            logger,
+            "Invalid parameter: Attributes Reason: RawMessageDelivery: Invalid value ${attributeValue}. Must be true or false.",
+        )
+        return@route
+    }
+
     val updatedAttributes = subscription.subscriptionAttributes + mapOf(
         attributeName to attributeValue
     )

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/setSubscriptionAttributesRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/setSubscriptionAttributesRoute.kt
@@ -42,6 +42,7 @@ val setSubscriptionAttributesRoute: (RoutingContext) -> Unit = route@{ ctx: Rout
         sub.arn != updatedSubscription.arn
     } + listOf(updatedSubscription)
     subscriptionsMap[subscription.topicArn] = updatedSubscriptions
+    vertx.eventBus().publish("configChange", "configChange")
     ctx.request().response()
         .putHeader("context-type", "text/xml")
         .setStatusCode(200)

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/subscribeRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/subscribeRoute.kt
@@ -1,8 +1,8 @@
 package com.jameskbride.localsns.routes.subscriptions
 
 import com.jameskbride.localsns.*
-import com.jameskbride.localsns.models.MessageAttribute
 import com.jameskbride.localsns.models.Subscription
+import com.jameskbride.localsns.models.SubscriptionAttribute
 import com.jameskbride.localsns.models.Topic
 import com.typesafe.config.ConfigFactory
 import io.vertx.ext.web.RoutingContext
@@ -46,16 +46,15 @@ val subscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         return@route
     }
     logger.info("Attributes passed to subscribe: $attributes")
-    val messageAttributes:Map<String, MessageAttribute> = MessageAttribute.parse(attributes
-        .filter { it.key.startsWith("Attributes.entry") }
-        .filterNot { it.key.matches(".*\\.DataType.*".toRegex()) }
+    val subscriptionAttributes:Map<String, SubscriptionAttribute> = SubscriptionAttribute.parse(
+        attributes.filter { it.key.startsWith("Attributes.entry") }
     )
 
-    if (messageAttributes.containsKey("RawMessageDelivery") && !listOf("true", "false").contains(messageAttributes["RawMessageDelivery"]!!.value)) {
+    if (subscriptionAttributes.containsKey("RawMessageDelivery") && !listOf("true", "false").contains(subscriptionAttributes["RawMessageDelivery"]!!.value)) {
         logAndReturnError(
             ctx,
             logger,
-            "Invalid parameter: Attributes Reason: RawMessageDelivery: Invalid value ${messageAttributes["RawMessageDelivery"]!!.value}. Must be true or false.",
+            "Invalid parameter: Attributes Reason: RawMessageDelivery: Invalid value ${subscriptionAttributes["RawMessageDelivery"]!!.value}. Must be true or false.",
         )
         return@route
     }
@@ -68,7 +67,7 @@ val subscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         topicArn = topicArn,
         protocol = protocol,
         endpoint = endpoint,
-        subscriptionAttributes = messageAttributes.values.map { mapOf(it.name to it.value) }.fold(mapOf()) { acc, map -> acc + map }
+        subscriptionAttributes = subscriptionAttributes.values.map { mapOf(it.name to it.value) }.fold(mapOf()) { acc, map -> acc + map }
     )
     logger.info("Creating subscription: {}", subscription)
     val updatedSubscriptions = subscriptions.getOrDefault(topicArn, listOf()) + subscription

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/subscribeRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/subscribeRoute.kt
@@ -79,14 +79,14 @@ val subscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         .putHeader("context-type", "text/xml")
         .end(
             """
-                      <SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-                        <SubscribeResult>
-                          <SubscriptionArn>${subscription.arn}</SubscriptionArn>
-                        </SubscribeResult>
-                        <ResponseMetadata>
-                          <RequestId>${UUID.randomUUID()}</RequestId>
-                        </ResponseMetadata>
-                      </SubscribeResponse>
-                    """.trimIndent()
+              <SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+                <SubscribeResult>
+                  <SubscriptionArn>${subscription.arn}</SubscriptionArn>
+                </SubscribeResult>
+                <ResponseMetadata>
+                  <RequestId>${UUID.randomUUID()}</RequestId>
+                </ResponseMetadata>
+              </SubscribeResponse>
+            """.trimIndent()
         )
 }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/subscribeRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/subscribeRoute.kt
@@ -46,15 +46,15 @@ val subscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         return@route
     }
     logger.info("Attributes passed to subscribe: $attributes")
-    val subscriptionAttributes:Map<String, SubscriptionAttribute> = SubscriptionAttribute.parse(
+    val subscriptionAttributes:Map<String, String> = SubscriptionAttribute.parse(
         attributes.filter { it.key.startsWith("Attributes.entry") }
     )
 
-    if (subscriptionAttributes.containsKey("RawMessageDelivery") && !listOf("true", "false").contains(subscriptionAttributes["RawMessageDelivery"]!!.value)) {
+    if (subscriptionAttributes.containsKey("RawMessageDelivery") && !listOf("true", "false").contains(subscriptionAttributes["RawMessageDelivery"])) {
         logAndReturnError(
             ctx,
             logger,
-            "Invalid parameter: Attributes Reason: RawMessageDelivery: Invalid value ${subscriptionAttributes["RawMessageDelivery"]!!.value}. Must be true or false.",
+            "Invalid parameter: Attributes Reason: RawMessageDelivery: Invalid value ${subscriptionAttributes["RawMessageDelivery"]}. Must be true or false.",
         )
         return@route
     }
@@ -67,7 +67,7 @@ val subscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         topicArn = topicArn,
         protocol = protocol,
         endpoint = endpoint,
-        subscriptionAttributes = subscriptionAttributes.values.map { mapOf(it.name to it.value) }.fold(mapOf()) { acc, map -> acc + map }
+        subscriptionAttributes = subscriptionAttributes
     )
     logger.info("Creating subscription: {}", subscription)
     val updatedSubscriptions = subscriptions.getOrDefault(topicArn, listOf()) + subscription

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -56,7 +56,7 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         return@route
     }
 
-    val messageAttributes = MessageAttribute.parse(attributes).associate { it.name to it.value }
+    val messageAttributes:Map<String, MessageAttribute> = MessageAttribute.parse(attributes)
     val subscriptionsMap = getSubscriptionsMap(vertx)
     val subscriptions = subscriptionsMap!!.getOrDefault(topicArn, listOf())
     val camelContext = DefaultCamelContext()
@@ -96,7 +96,7 @@ private fun publishJsonStructure(
     logger: Logger,
     subscriptions: List<Subscription>,
     producerTemplate: ProducerTemplate,
-    messageAttributes: Map<String, String>
+    messageAttributes: Map<String, MessageAttribute>
 ): Boolean {
     try {
         val messages = JsonObject(message)
@@ -131,7 +131,7 @@ private fun publishBasicMessage(
     logger: Logger,
     message: String,
     producerTemplate: ProducerTemplate,
-    messageAttributes: Map<String, String>
+    messageAttributes: Map<String, MessageAttribute>
 ) {
     subscriptions.forEach { subscription ->
         try {
@@ -150,11 +150,11 @@ fun getTopicArn(topicArn: String?, targetArn: String?): String? {
 private fun publishMessage(
     subscription: Subscription,
     message: String,
-    messageAttributes: Map<String, String>,
+    messageAttributes: Map<String, MessageAttribute>,
     producer: ProducerTemplate,
     logger: Logger
 ) {
-    val headers = messageAttributes.map { it.key to it.value }.toMap() +
+    val headers = messageAttributes.map { it.key to it.value.value }.toMap() +
             mapOf(
                 "x-amz-sns-message-type" to "Notification",
                 "x-amz-sns-message-id" to UUID.randomUUID().toString(),

--- a/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
@@ -95,7 +95,7 @@ open class BaseTest {
         return postFormData(data)
     }
 
-    fun subscribe(topicArn: String?, endpoint: String?, protocol: String?, messageAttributes: Map<String, String> = mapOf()): Response {
+    fun subscribe(topicArn: String?, endpoint: String?, protocol: String?, subscriptionAttributes: Map<String, String> = mapOf()): Response {
         val data = mutableMapOf(
             "Action" to "Subscribe",
         )
@@ -109,11 +109,10 @@ open class BaseTest {
             data["Protocol"] = protocol
         }
 
-        messageAttributes.onEachIndexed { index, entry ->
+        subscriptionAttributes.onEachIndexed { index, entry ->
             val oneBasedIndex = index + 1
-            data["Attributes.entry.$oneBasedIndex.Name"]= entry.key
-            data["Attributes.entry.$oneBasedIndex.Value.StringValue"]= entry.value
-            data["Attributes.entry.$oneBasedIndex.DataType"] = "String"
+            data["Attributes.entry.$oneBasedIndex.key"]= entry.key
+            data["Attributes.entry.$oneBasedIndex.value"]= entry.value
         }
 
         return postFormData(data)

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -342,7 +342,7 @@ class PublishRouteIntegrationTest: BaseTest() {
     }
 
     @Test
-    fun `it can publish using MessageStructure`(vertx: Vertx, testContext: VertxTestContext) {
+    fun `it can publish using MessageStructure`(testContext: VertxTestContext) {
         data class Message(val default: String, val http:String): Serializable
         data class JsonMessage(val key:String):Serializable
         val httpMessage = Json.encode(JsonMessage("hello http"))
@@ -370,7 +370,7 @@ class PublishRouteIntegrationTest: BaseTest() {
     }
 
     @Test
-    fun `it can publish raw http messages using MessageStructure`(vertx: Vertx, testContext: VertxTestContext) {
+    fun `it can publish raw http messages using MessageStructure`(testContext: VertxTestContext) {
         data class Message(val default: String, val http:String): Serializable
         data class JsonMessage(val key:String):Serializable
         val httpMessage = Json.encode(JsonMessage("hello http"))
@@ -379,8 +379,7 @@ class PublishRouteIntegrationTest: BaseTest() {
         // Define a POST route
         router.post("/testEndpoint").handler { routingContext ->
             val request = routingContext.request()
-            request.bodyHandler { body ->
-                val requestBody = body.toString("UTF-8")
+            request.bodyHandler {
                 assertEquals(message.http, httpMessage)
                 testContext.completeNow()
             }
@@ -402,7 +401,7 @@ class PublishRouteIntegrationTest: BaseTest() {
     }
 
     @Test
-    fun `it can publish raw sqs messages using MessageStructure`(vertx: Vertx, testContext: VertxTestContext) {
+    fun `it can publish raw sqs messages using MessageStructure`(testContext: VertxTestContext) {
         data class Message(val default: String, val sqs:String): Serializable
         data class JsonMessage(val key:String):Serializable
         val jsonMessage = Json.encode(JsonMessage("hello sqs"))

--- a/src/test/kotlin/com/jameskbride/localsns/SetSubscriptionAttributesRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/SetSubscriptionAttributesRouteTest.kt
@@ -69,4 +69,16 @@ class SetSubscriptionAttributesRouteTest: BaseTest() {
 
         testContext.completeNow()
     }
+
+    @Test
+    fun `it triggers a database save when the message attribute is set`(vertx: Vertx, testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs"))
+
+        vertx.eventBus().consumer<String>("configChange") {
+            testContext.completeNow()
+        }
+
+        setSubscriptionAttributes(subscriptionArn, "RawMessageDelivery", "true")
+    }
 }

--- a/src/test/kotlin/com/jameskbride/localsns/SetSubscriptionAttributesRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/SetSubscriptionAttributesRouteTest.kt
@@ -50,6 +50,18 @@ class SetSubscriptionAttributesRouteTest: BaseTest() {
     }
 
     @Test
+    fun `it returns an error when RawMessageDelivery attribute value is invalid`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val subscriptionArn = getSubscriptionArnFromResponse(subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs"))
+
+        val response = setSubscriptionAttributes(subscriptionArn, attributeName = "RawMessageDelivery", "not true or false")
+
+        assertEquals(400, response.statusCode)
+
+        testContext.completeNow()
+    }
+
+    @Test
     fun `it returns an error when SubscriptionArn does not exist`(testContext: VertxTestContext) {
         val response = setSubscriptionAttributes(createValidArn("queue1"), attributeName = "name", "name")
 

--- a/src/test/kotlin/com/jameskbride/localsns/SubscribeRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/SubscribeRouteTest.kt
@@ -82,12 +82,12 @@ class SubscribeRouteTest : BaseTest() {
 
     @Test
     fun `it can subscribe with message attributes`(testContext: VertxTestContext) {
-        val messageAttributes = mapOf(
+        val subscriptionAttributes = mapOf(
             "FilterPolicy" to "the policy"
         )
         val topic = createTopicModel("topic1")
 
-        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs", messageAttributes)
+        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs", subscriptionAttributes)
         val subscriptionArn = getSubscriptionArnFromResponse(response)
         assertEquals(200, response.statusCode)
         assertTrue(subscriptionArn.isNotEmpty())
@@ -101,12 +101,12 @@ class SubscribeRouteTest : BaseTest() {
 
     @Test
     fun `it returns an error when the RawMessageDelivery value is invalid`(testContext: VertxTestContext) {
-        val messageAttributes = mapOf(
+        val subscriptionAttributes = mapOf(
             "RawMessageDelivery" to ""
         )
         val topic = createTopicModel("topic1")
 
-        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs", messageAttributes)
+        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs", subscriptionAttributes)
         getSubscriptionArnFromResponse(response)
         assertEquals(400, response.statusCode)
 

--- a/src/test/kotlin/com/jameskbride/localsns/SubscribeRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/SubscribeRouteTest.kt
@@ -98,4 +98,18 @@ class SubscribeRouteTest : BaseTest() {
 
         testContext.completeNow()
     }
+
+    @Test
+    fun `it returns an error when the RawMessageDelivery value is invalid`(testContext: VertxTestContext) {
+        val messageAttributes = mapOf(
+            "RawMessageDelivery" to ""
+        )
+        val topic = createTopicModel("topic1")
+
+        val response = subscribe(topic.arn, createSqsEndpoint("queue1"), "sqs", messageAttributes)
+        getSubscriptionArnFromResponse(response)
+        assertEquals(400, response.statusCode)
+
+        testContext.completeNow()
+    }
 }


### PR DESCRIPTION
# Context
This PR enables subscription attributes to be persisted in the `DB_PATH` and `DB_OUTPUT_PATH` files.

# Changes
- Removing `JsonIgnore` on `Subscription.subscriptionAttributes` so subscription attributes can be persisted.
- Triggering database save when `SetSubscriptionAttributes` is invoked.
- Clearing warnings.

# Testing and Validation Steps

## Subscribe
1. Create a new subscription with one or more subscription attributes.
2. Validate that the subscription attributes are written to the `db.json` file.

## Set Subscription Attributes
1. Create a subscription.
2. Set a subscription attribute.
3. Validate that the subscription attribute is written the the `db.json` file.
