### PR TITLE
Correcting endpoint formatting.

### DIFF
--- a/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/Subscription.kt
@@ -23,4 +23,8 @@ data class Subscription(
   @JsonIgnore fun isRawMessageDelivery(): Boolean {
     return subscriptionAttributes.getOrDefault("RawMessageDelivery", "false") == "true"
   }
+
+  @JsonIgnore fun xmlEncodeEndpointUrl(): String? {
+    return endpoint?.replace("&", "&amp;") ?: endpoint
+  }
 }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/getSubscriptionAttributesRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/getSubscriptionAttributesRoute.kt
@@ -37,7 +37,7 @@ var getSubscriptionAttributesRoute: (RoutingContext) -> Unit = route@{ ctx: Rout
         return@route
     }
 
-    val endpoint = URLEncoder.encode(subscription.endpoint.orEmpty(), "UTF-8")
+    val endpoint = subscription.xmlEncodeEndpointUrl()
     val mergedAttributes = mapOf(
         "SubscriptionArn" to subscription.arn,
         "TopicArn" to subscription.topicArn,

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/listSubscriptionsByTopicRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/listSubscriptionsByTopicRoute.kt
@@ -35,7 +35,7 @@ val listSubscriptionsByTopicRoute: (RoutingContext) -> Unit = route@{ ctx: Routi
     val sharedData = getSubscriptionsMap(vertx)
     val subscriptions = sharedData!!.getOrDefault(topicArn, listOf())
     val subscriptionsContent = subscriptions.map { subscription ->
-        val endpoint = URLEncoder.encode(subscription.endpoint.orEmpty(), "UTF-8")
+        val endpoint = subscription.xmlEncodeEndpointUrl()
         """
             <member>
                 <Owner>${subscription.owner}</Owner>

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/listSubscriptionsRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/listSubscriptionsRoute.kt
@@ -11,7 +11,7 @@ val listSubscriptionsRoute: (RoutingContext) -> Unit = { ctx: RoutingContext ->
     val sharedData = getSubscriptionsMap(vertx)
     val subscriptions = sharedData!!.values.fold(listOf<Subscription>()) { acc, subscriptions -> acc + subscriptions }
     val subscriptionsContent = subscriptions.map{subscription ->
-        val endpoint = URLEncoder.encode(subscription.endpoint.orEmpty(), "UTF-8")
+        val endpoint = subscription.xmlEncodeEndpointUrl()
         """
         <member>
             <Owner>${subscription.owner}</Owner>

--- a/src/test/kotlin/com/jameskbride/localsns/GetSubscriptionAttributesRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/GetSubscriptionAttributesRouteTest.kt
@@ -60,7 +60,7 @@ class GetSubscriptionAttributesRouteTest: BaseTest() {
         assertAttributeFound(entries, "SubscriptionArn", subscriptionArn)
         assertAttributeFound(entries, "TopicArn", topic.arn)
         assertAttributeFound(entries, "Owner", "")
-        assertAttributeFound(entries, "Endpoint", URLEncoder.encode(endpoint, "UTF-8"))
+        assertAttributeFound(entries, "Endpoint", endpoint)
         assertAttributeFound(entries, "Protocol", "sqs")
         assertAttributeFound(entries, "PendingConfirmation", "false")
         assertAttributeFound(entries, "SubscriptionPrincipal", "")

--- a/src/test/kotlin/com/jameskbride/localsns/ListSubscriptionsByTopicRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/ListSubscriptionsByTopicRouteTest.kt
@@ -82,6 +82,11 @@ class ListSubscriptionsByTopicRouteTest: BaseTest() {
                 .contains("sqs") && text.contains("queue1")
         })
 
+        Assertions.assertTrue(members.any {
+            val text = it.text()
+            text.contains("Endpoint") && text.contains(endpoint1)
+        })
+
         //Only return subscriptions for the requested topic
         Assertions.assertTrue(members.none {
             val text = it.text()


### PR DESCRIPTION
# Context
The endpoint for each subscription was not rendering correctly in the responses because we were URL encoding the value. This caused endpoints to render in the URL encoded format instead of the expected unencoded format. Because the response is an XML response we need to encode `&` characters as `&amp;` instead of URL encoding the entire endpoint.

# Changes
* Added an `xmlEncodedEndpointUrl()` method to the `Subscription` data class.
* Updated responses which include the endpoint value (`ListSubscriptions`, `ListSubscriptionsByTopic`, `GetSubscriptionAttributes`) to use the XML-encoded endpoint url. 

# Testing and Validation Steps
1. Create a subscription with an endpoint that includes an `&` character.
2. Run `aws sns list-subscriptions --endpoint-url http://localhost:9911`.
3. Validate that the subscription endpoint renders correctly with the `&`.
4. Run `aws sns get-subscription-attributes --endpoint-url http://localhost:9911 --subscription-arn <subscription-arn>`.
5. Validate that the subscription endpoint renders correctly with the `&`.
6. Run `aws sns list-subscritptions-by-topic --endpoint-url http://localhost:9911 --topic-arn <subscription topic arn>`.
7. Validate that the subscription endpoint renders correctly with the `&`.
