### PR TITLE
Add main Workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,23 @@
+name: Gradle Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build, Test, and Docker Build
+    name: Build, Test
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/jameskbride/local-sns.svg?maxAge=2592000)](https://hub.docker.com/r/jameskbride/localsns/)
+[![CI/CD for local-sns main](https://github.com/jameskbride/local-sns/actions/workflows/main.yaml/badge.svg)](https://github.com/jameskbride/local-sns/actions/workflows/main.yaml)
+
 
 # Local SNS
 Fake Amazon Simple Notification Service (SNS) for local development. Supports:
 - Create/List/Delete topics
-- Subscribe endpoint
+- Subscribe/unsubscribe endpoints
+- List subscriptions, list subscriptions by topic endpoints
+- Get/Set subscription attribute endpoints
 - Publish message
-- Subscription persistence
+- Subscription persistence to file, including subscription attributes
 - Integrations with (Fake-)SQS, File, HTTP, RabbitMQ, Slack, and Lambda
 
 ## Usage


### PR DESCRIPTION
# Context
Need to add the workflow to run the build on push to `main`.

# Changes
- Adding the main workflow.
- Minor workflow step name change.
- Adding the CI/CD workflow badge to the README. Updating the README with more detail.

# Testing and Validation Steps
