### PR TITLE
Filter Policy - Basic field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Example: `aws2-sqs://{{env:QUEUE_NAME}}?amazonSQSEndpoint={{env:SQS_ENDPOINT}}&.
 Tested with [elasticmq](https://github.com/adamw/elasticmq).
 
 ```
-docker run -d -p 9911:9911 -v "$PWD/example/config":/etc/sns jameskbride/local-sns
+cd example
+docker-compose up
 ```
 
 ## Development

--- a/example/config/db.json
+++ b/example/config/db.json
@@ -6,16 +6,33 @@
     "owner" : "",
     "topicArn" : "arn:aws:sns:us-east-1:1465414804035:test1",
     "protocol" : "sqs",
-    "endpoint" : "aws2-sqs://queue1?accessKey=xxx&secretKey=xxx&region=us-east-1&trustAllCertificates=true&overrideEndpoint=true&uriEndpointOverride=http://sqs:9324"
+    "endpoint" : "aws2-sqs://queue1?accessKey=xxx&secretKey=xxx&region=us-east-1&trustAllCertificates=true&overrideEndpoint=true&uriEndpointOverride=http://sqs:9324",
+    "subscriptionAttributes" : {
+      "FilterPolicy" : "{\"status\": [\"not_sent\", \"resend\"], \"amount\": [10.5], \"sold\": [true] }",
+      "FilterPolicyScope" : "MessageBody"
+    }
   }, {
     "arn" : "6df4ed2b-a650-4f7c-910a-1a89c7cae5a6",
     "owner" : "",
     "topicArn" : "arn:aws:sns:us-east-1:1465414804035:test1",
     "protocol" : "file",
-    "endpoint" : "file://tmp/logs?fileName=messages.log&fileExist=Append&appendChars=\\n"
+    "endpoint" : "file://tmp/logs?fileName=messages.log&fileExist=Append&appendChars=\\n",
+    "subscriptionAttributes" : {
+      "FilterPolicy" : "{\"status\": [\"not_sent\", \"resend\"], \"amount\": [10.5], \"sold\": [true] }",
+      "RawMessageDelivery" : "true"
+    }
+  }, {
+    "arn" : "25da5e63-d5d3-469d-9e0c-e33539948bd1",
+    "owner" : "",
+    "topicArn" : "arn:aws:sns:us-east-1:1465414804035:test2",
+    "protocol" : "file",
+    "endpoint" : "file://tmp/logs?fileName=no-attributes.log&fileExist=Append&appendChars=\\n"
   } ],
   "topics" : [ {
     "arn" : "arn:aws:sns:us-east-1:1465414804035:test1",
     "name" : "test1"
+  }, {
+    "arn" : "arn:aws:sns:us-east-1:1465414804035:test2",
+    "name" : "test2"
   } ]
 }

--- a/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
@@ -4,7 +4,7 @@ import java.io.Serializable
 
 private const val ATTRIBUTE_PATTERN = ".*Attributes\\.entry\\.(\\d+)\\.(.*?)"
 
-data class MessageAttribute(val name:String, val value:String): Serializable {
+data class MessageAttribute(val name:String, val value:String, val dataType:String = "String"): Serializable {
     companion object {
         fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, MessageAttribute> {
             val pattern = ATTRIBUTE_PATTERN.toRegex()

--- a/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
@@ -6,7 +6,7 @@ private const val ATTRIBUTE_PATTERN = ".*Attributes\\.entry\\.(\\d+)\\.(.*?)"
 
 data class MessageAttribute(val name:String, val value:String, val dataType:String = "String"): Serializable {
     companion object {
-        fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, MessageAttribute> {
+        fun parse(attributes: List<Map.Entry<String, String>>): Map<String, MessageAttribute> {
             val pattern = ATTRIBUTE_PATTERN.toRegex()
             val entryNumbers = attributes.map { attribute ->
                 val match = pattern.matchEntire(attribute.key)

--- a/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/MessageAttribute.kt
@@ -24,7 +24,12 @@ data class MessageAttribute(val name:String, val value:String, val dataType:Stri
                     it.key.matches(namePattern.toRegex())
                 }!!.value
 
-                mapOf(name to MessageAttribute(name, value))
+                val dataType = attributes.find {
+                    val namePattern = ".*Attributes\\.entry\\.$entryNumber.Value.DataType"
+                    it.key.matches(namePattern.toRegex())
+                }!!.value
+
+                mapOf(name to MessageAttribute(name, value, dataType))
             }.fold(mapOf<String, MessageAttribute>()) { acc, map -> acc + map }
 
             return messageAttributes

--- a/src/main/kotlin/com/jameskbride/localsns/models/SubscriptionAttribute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/SubscriptionAttribute.kt
@@ -4,6 +4,9 @@ private const val SUBSCRIPTION_ATTRIBUTE_PATTERN = ".*Attributes\\.entry\\.(\\d+
 
 data class SubscriptionAttribute(val name:String, val value:String) {
     companion object {
+
+        const val FILTER_POLICY = "FilterPolicy"
+
         fun parse(attributes: List<MutableMap.MutableEntry<String, String>>): Map<String, String> {
             val pattern = SUBSCRIPTION_ATTRIBUTE_PATTERN.toRegex()
             val entryNumbers = attributes.map { attribute ->

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -27,7 +27,6 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
     logger.info("MessageAttributes passed to publish: $formAttributes")
     val attributes = formAttributes
         .filter { it.key.startsWith("MessageAttributes.entry") }
-        .filterNot { it.key.matches(".*\\.DataType.*".toRegex()) }
     val vertx = ctx.vertx()
 
     if (topicArn == null) {

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -1,9 +1,9 @@
 package com.jameskbride.localsns.routes.topics
 
 import com.google.gson.Gson
-import com.google.gson.JsonArray
 import com.jameskbride.localsns.*
 import com.jameskbride.localsns.models.*
+import com.jameskbride.localsns.models.SubscriptionAttribute.Companion.FILTER_POLICY
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.web.RoutingContext
 import io.vertx.kotlin.core.json.get
@@ -147,8 +147,6 @@ private fun publishBasicMessage(
 fun getTopicArn(topicArn: String?, targetArn: String?): String? {
     return topicArn ?: targetArn
 }
-
-private const val FILTER_POLICY = "FilterPolicy"
 
 private fun publishMessage(
     subscription: Subscription,

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -206,9 +206,22 @@ private fun matchesFilterPolicy(
         if (!messageAttributes.containsKey(it.key)) {
             false
         } else {
-            val permittedValues = it.value as List<String>
+            val permittedValues = it.value as List<*>
             val messageAttribute = messageAttributes[it.key]
-            permittedValues.contains(messageAttribute!!.value)
+            when (messageAttribute!!.dataType) {
+                "Number" -> {
+                    val parsedAttribute = messageAttribute.value.toDouble()
+                    permittedValues.contains(parsedAttribute)
+                }
+                else -> {
+                    permittedValues.any {permittedValue ->
+                        when (permittedValue) {
+                            (permittedValue is Boolean) -> permittedValue.toString() == messageAttribute.value
+                            else -> permittedValue == messageAttribute.value
+                        }
+                    }
+                }
+            }
         }
     }
     return matched

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -221,8 +221,8 @@ private fun matchesFilterPolicy(subscription: Subscription, message:String): Boo
         if (!messageJson.containsKey(it.key)) {
             false
         } else {
-            val permittedValues = it.value as List<String>
-            val messageAttribute = messageJson.getString(it.key)
+            val permittedValues = it.value as List<*>
+            val messageAttribute = messageJson.getValue(it.key)
             permittedValues.contains(messageAttribute!!)
         }
     }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -154,6 +154,9 @@ private fun publishMessage(
     producer: ProducerTemplate,
     logger: Logger
 ) {
+    if (subscription.subscriptionAttributes.containsKey("FilterPolicy")) {
+        return
+    }
     val headers = messageAttributes.map { it.key to it.value.value }.toMap() +
             mapOf(
                 "x-amz-sns-message-type" to "Notification",

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -23,7 +23,9 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
     val topicArn = getTopicArn(topicArnFormAttribute, targetArnFormAttribute)
     val message = getFormAttribute(ctx, "Message")
     val messageStructure = getFormAttribute(ctx, "MessageStructure")
-    val attributes = ctx.request().formAttributes()
+    val formAttributes = ctx.request().formAttributes()
+    logger.info("MessageAttributes passed to publish: $formAttributes")
+    val attributes = formAttributes
         .filter { it.key.startsWith("MessageAttributes.entry") }
         .filterNot { it.key.matches(".*\\.DataType.*".toRegex()) }
     val vertx = ctx.vertx()

--- a/src/test/kotlin/com/jameskbride/localsns/MessageAttributeTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/MessageAttributeTest.kt
@@ -1,0 +1,26 @@
+package com.jameskbride.localsns
+
+import com.jameskbride.localsns.models.MessageAttribute
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MessageAttributeTest {
+
+    @Test
+    fun `it can parse StringValue attributes`() {
+        val rawAttributes = mapOf(
+            "MessageAttributes.entry.1.Name" to "status",
+            "MessageAttributes.entry.1.Value.DataType" to "String",
+            "MessageAttributes.entry.1.Value.StringValue" to "not_sent"
+        ).entries.toList()
+
+        val messageAttributes = MessageAttribute.parse(rawAttributes)
+        assertTrue(messageAttributes.keys.contains("status"))
+
+        val messageAttribute = messageAttributes["status"]
+        assertEquals("status", messageAttribute!!.name)
+        assertEquals("String", messageAttribute.dataType)
+        assertEquals("not_sent", messageAttribute.value)
+    }
+}

--- a/src/test/kotlin/com/jameskbride/localsns/MessageAttributeTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/MessageAttributeTest.kt
@@ -23,4 +23,21 @@ class MessageAttributeTest {
         assertEquals("String", messageAttribute.dataType)
         assertEquals("not_sent", messageAttribute.value)
     }
+
+    @Test
+    fun `it can parse Number attributes`() {
+        val rawAttributes = mapOf(
+            "MessageAttributes.entry.1.Name" to "amount",
+            "MessageAttributes.entry.1.Value.DataType" to "Number",
+            "MessageAttributes.entry.1.Value.StringValue" to "10.56"
+        ).entries.toList()
+
+        val messageAttributes = MessageAttribute.parse(rawAttributes)
+        assertTrue(messageAttributes.keys.contains("amount"))
+
+        val messageAttribute = messageAttributes["amount"]
+        assertEquals("amount", messageAttribute!!.name)
+        assertEquals("Number", messageAttribute.dataType)
+        assertEquals("10.56", messageAttribute.value)
+    }
 }

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -36,10 +36,6 @@ import java.net.URI
 
 private const val ELASTIC_MQ_SERVER_URL = "http://localhost:9324/000000000000"
 
-fun createQueueUrl(queueName: String): String {
-    return "$ELASTIC_MQ_SERVER_URL/$queueName"
-}
-
 @ExtendWith(VertxExtension::class)
 class PublishRouteIntegrationTest: BaseTest() {
 

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -336,9 +336,9 @@ class PublishRouteIntegrationTest: BaseTest() {
         val topic = createTopicModel("topic1")
         val queueName = "filter-policy-messagebody-multiple-queue"
         val endpoint = createQueue(queueName)
-        data class FilterPolicy(val status:List<String>, val type:List<String>): Serializable
+        data class FilterPolicy(val status:List<String>, val amount:List<Double>, val sold:List<Boolean>): Serializable
         val gson = Gson()
-        val filterPolicy = FilterPolicy(status=listOf("not_sent"), type=listOf("notification"))
+        val filterPolicy = FilterPolicy(status=listOf("not_sent"), amount=listOf(5.0), sold=listOf(true))
         subscribe(
             topic.arn,
             endpoint,
@@ -348,8 +348,8 @@ class PublishRouteIntegrationTest: BaseTest() {
                 "FilterPolicyScope" to "MessageBody",
             )
         )
-        data class Message(val status:String, val type:String)
-        val message = Message(status="not_sent", type="notification")
+        data class Message(val status:String, val amount:Double, val sold:Boolean)
+        val message = Message(status="not_sent", amount=5.0, sold=true)
 
         val request = publishRequest(
             topic,

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -191,6 +191,46 @@ class PublishRouteIntegrationTest: BaseTest() {
     }
 
     @Test
+    fun `FilterPolicy - it does not publish when one or more attributes do not match`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = "filter-policy-queue"
+        val endpoint = createQueue(queueName)
+        data class FilterPolicy(val status:List<String>, val amount:List<Double>, val sold:List<Boolean>): Serializable
+        val gson = Gson()
+        val filterPolicy = FilterPolicy(status=listOf("not_sent"), amount=listOf(10.5), sold=listOf(true))
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to gson.toJson(filterPolicy)
+            )
+        )
+        val message = "Hello, SNS!"
+
+        val request = publishRequest(
+            topic,
+            message,
+            mapOf(
+                "status" to "not_sent",
+                "amount" to "5.0",
+                "sold" to "true"
+            )
+        )
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("status")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.failNow("Message was not filtered")
+            } else {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
     fun `it can publish raw messages to sqs`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val queueName = "raw-queue"

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -741,7 +741,12 @@ class PublishRouteIntegrationTest: BaseTest() {
         messageStructure: String? = null,
     ): PublishRequest? {
         val attributes =
-            messageAttributes.map { it.key to MessageAttributeValue.builder().stringValue(it.value).build() }.toMap()
+            messageAttributes.map { it.key to MessageAttributeValue.builder()
+                .apply {
+                    stringValue(it.value)
+                    dataType("String")
+                }.build()
+            }.toMap()
         return PublishRequest.builder()
             .apply {
                 if (useTargetArn) {


### PR DESCRIPTION
# Context
Addresses #2 

# Changes
- Implemented basic MessageAttributes filter policy for simple attribute matching.
- - Supporting MessageAttributes filter policy for value types other than String, including Number, and boolean (boolean is still a String per the docs).
- Implemented basic MessageBody filter policy for simple attribute matching.
- Supporting MessageBody filter policy for value types other than String, including Number, and boolean (boolean is still a String per the docs).
- Adding logging to publish.
- Updated the example configuration to be more descriptive.