### PR TITLE
Log the version on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ DB_PATH := ./db.json
 
 TAG = dev
 
+JAR ?= $(wildcard build/libs/local-sns-*.jar)
+
 run-dev:
 	DB_PATH=$(DB_PATH) ./gradlew run
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,16 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
-import org.gradle.internal.classpath.Instrumented.systemProperty
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.gradle.tasks.KotlinTest
+import com.typesafe.config.ConfigFactory
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath("com.typesafe:config:1.4.2")
+  }
+}
 
 plugins {
   kotlin ("jvm") version "1.9.0"
@@ -11,7 +19,8 @@ plugins {
 }
 
 group = "com.jameskbride.localsns"
-version = project.version
+val typesafeConf = ConfigFactory.parseFile(File("src/main/resources/application.conf"))
+version = typesafeConf.getString("version")
 
 repositories {
   mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
 kotlin.code.style=official
-version=0.10.1-alpha

--- a/src/main/kotlin/com/jameskbride/localsns/Main.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/Main.kt
@@ -22,6 +22,7 @@ class Main {
         fun main(args: Array<String>) {
             configureObjectMappers()
             val config = ConfigFactory.load()
+            logger.info("Starting local-sns-${config.getValue("version").unwrapped()}")
             val vertx = Vertx.vertx()
             val dbPath = getDbPath(config)
             vertx.fileSystem()

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -12,3 +12,5 @@ aws {
     accountId = "123456789012"
     region = "us-east-1"
 }
+
+version = "0.10.1-alpha"


### PR DESCRIPTION
# Context
Log the local-sns version on startup to make troubleshooting easier.

# Changes
* Log the version on startup.
* Move the version definition into `src/main/resources/application.conf`
* Read the version from `application.conf` when building the versioned
  jar.
* Updated the Makefile to dynamically read the jar version when building
  and publishing the Docker image.

# Testing and Validation Steps
<img width="560" alt="Screenshot 2023-12-27 at 4 37 01 PM" src="https://github.com/jameskbride/local-sns/assets/1082328/a770dbf8-6c16-4efe-96f7-11f0bfaafbd0">
