### PR TITLE
Replace Deprecated Base Docker Image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '11'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '11'
 
       - name: Build with Gradle

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '11'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '11'
 
       - name: Build and Test with Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/s12v/sns/issues/60
-FROM openjdk:11.0.13-jre-slim
+FROM amazoncorretto:11.0.21-alpine
 
 EXPOSE 9911
 
@@ -12,10 +12,9 @@ ENV AWS_DEFAULT_REGION=us-east-1 \
 	DB_PATH=/etc/sns/db.json \
 	DB_OUTPUT_PATH=/etc/sns/db.json
 
-# Install the AWS CLI using apt
-RUN apt-get update && \
-    apt-get install -y awscli && \
-    apt-get clean
+RUN apk update \
+    && apk add --no-cache aws-cli \
+    && apk cache clean
 
 ARG JAR=undefined
 ADD $JAR /local-sns.jar

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fake Amazon Simple Notification Service (SNS) for local development. Supports:
 
 ### Docker
 
-Based on the `openjdk:11.0.13-jre-slim` image. Run it with the command:
+Based on the `amazoncorretto:11.0.21-alpine` image. Run it with the command:
 ```
 docker run -d -p 9911:9911 jameskbride/local-sns
 ```


### PR DESCRIPTION
# Context
The [OpenJDK Docker image](https://github.com/docker-library/openjdk/issues/505) has been retired and will no longer be maintained. This PR updates the Dockerfile to use `amazoncorretto:11.0.21-alpine` as it results in a smaller image and is still maintained. 

# Changes
- Updating the Dockerfile to be based on amazoncorretto:11.0.21-alpine
- Updating CI to use Corretto.
- Updating the README to reference Corretto.

# Testing and Validation Steps
1. Build the image via `make build-image`.
2. Validate that the image built successfully.
3. Run local-sns from docker.
4. Validate that it starts up as expected.
5. Run the aws cli via docker: `docker exec <CONTAINER_ID> sh -c 'aws sns --endpoint-url http://localhost:9911 list-subscriptions'`
6. Validate that the command completes successfully.
