### PR TITLE
Correcting Exact Number Matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Fake Amazon Simple Notification Service (SNS) for local development. Supports:
 - Get/Set subscription attribute endpoints
 - Publish message
 - Subscription persistence to file, including subscription attributes
+- Subscription filtering (currently under development with some alpha features)
 - Integrations with (Fake-)SQS, File, HTTP, RabbitMQ, Slack, and Lambda
 
 ## Usage
@@ -74,6 +75,31 @@ Tested with [elasticmq](https://github.com/adamw/elasticmq).
 cd example
 docker-compose up
 ```
+
+## Features
+### Subscriptions
+#### Supported Subscription Attributes (See [SetSubscriptionAttributes](https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html))
+* `RawMessageDelivery` - NOTE: Messages sent via a Slack endpoint are always sent raw.
+* `FilterPolicyScope` - Both `MessageBody` and `MessageAttributes` are supported (`MessageAttributes` is the default behavior).
+* `FilterPolicy` - Currently under development, supported for `MessageBody` and `MessageAttributes` with some limitations: 
+
+  | Feature                                                                                                                                                                                         | Supported                                                                                    |
+  |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+  | [Policy Complexity Constraints](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-common-constraints)                            | No                                                                                           |
+  | [Policy Constraints for MessageAttribute-based filtering](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-payload-constraints) | Yes (only `String` and `Number`; `String.Array` is not currently supported)                  |
+  | [Nested Constraints](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-payload-constraints) for payload-based filtering          | No (local-sns only supports top-level attribute filtering for `MessageBody` filter policies) |
+  | [Exact String match](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-exact-matching)                                                                                | Yes                                                                                          |
+  | [String anything-but match](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-anything-but-matching)                                                                  | No                                                                                           |
+  | [String prefix match](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-prefix-matching)                                                                              | No                                                                                           |
+  | [String suffix match](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#ip-suffix-matching)                                                                                  | No                                                                                           |
+  | [IP Address match](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#ip-address-matching)                                                                                     | No                                                                                           |
+  | [Exact Number match](https://docs.aws.amazon.com/sns/latest/dg/numeric-value-matching.html#numeric-exact-matching)                                                                              | Yes                                                                                          |
+  | [Numeric anything-but match](https://docs.aws.amazon.com/sns/latest/dg/numeric-value-matching.html#numeric-anything-but-matching)                                                               | No                                                                                           |
+  | [Numeric Value Range match](https://docs.aws.amazon.com/sns/latest/dg/numeric-value-matching.html#numeric-value-range-matching)                                                                 | No                                                                                           |
+  | [And Logic](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-payload-constraints)                                               | Yes                                                                                          |
+  | [Or Logic](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-payload-constraints)                                                | Yes                                                                                          |
+  | [Or Operator](https://docs.aws.amazon.com/sns/latest/dg/and-or-logic.html#or-operator)                                                                                                          | No                                                                                           |
+  | [Key Matching](https://docs.aws.amazon.com/sns/latest/dg/attribute-key-matching.html)                                                                                                           | No                                                                                           |
 
 ## Development
 This project uses Kotlin, [Vert.X](https://vertx.io), and [Apache Camel](https://camel.apache.org) for message routing.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fake Amazon Simple Notification Service (SNS) for local development. Supports:
 - Publish message
 - Subscription persistence to file, including subscription attributes
 - Subscription filtering (currently under development with some alpha features)
-- Integrations with (Fake-)SQS, File, HTTP, RabbitMQ, Slack, and Lambda
+- Integrations with SQS, File, HTTP, RabbitMQ, Slack, and Lambda
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ docker-compose up
 ## Development
 This project uses Kotlin, [Vert.X](https://vertx.io), and [Apache Camel](https://camel.apache.org) for message routing.
 
+Be sure to read the [SNS documentation](https://docs.aws.amazon.com/sns/latest/dg/welcome.html). The [API docs](https://docs.aws.amazon.com/sns/latest/api/API_Operations.html) in particular are useful.
+
+It's also useful to run the equivalent `aws sns` CLI command with the `--debug` flag to better understand what the request and response payloads look like. 
+
+You can also execute an `aws sns <command> --endpoint-url <local-sns url>` command to point the AWS CLI to the `local-sns` instance.
+
 ### Unit and Integration tests
 `./gradlew test`
 

--- a/example/config/db.json
+++ b/example/config/db.json
@@ -4,35 +4,35 @@
   "subscriptions" : [ {
     "arn" : "e9126059-9eab-4b37-8194-e0d64dfb2045",
     "owner" : "",
-    "topicArn" : "arn:aws:sns:us-east-1:1465414804035:test1",
+    "topicArn" : "arn:aws:sns:us-east-1:0123456789012:test1",
     "protocol" : "sqs",
     "endpoint" : "aws2-sqs://queue1?accessKey=xxx&secretKey=xxx&region=us-east-1&trustAllCertificates=true&overrideEndpoint=true&uriEndpointOverride=http://sqs:9324",
     "subscriptionAttributes" : {
-      "FilterPolicy" : "{\"status\": [\"not_sent\", \"resend\"], \"amount\": [10.5], \"sold\": [true] }",
+      "FilterPolicy" : "{\"status\": [\"not_sent\", \"resend\"], \"amount\": [{\"numeric\": [\"=\", 10.5]}], \"sold\": [true] }",
       "FilterPolicyScope" : "MessageBody"
     }
   }, {
     "arn" : "6df4ed2b-a650-4f7c-910a-1a89c7cae5a6",
     "owner" : "",
-    "topicArn" : "arn:aws:sns:us-east-1:1465414804035:test1",
+    "topicArn" : "arn:aws:sns:us-east-1:0123456789012:test1",
     "protocol" : "file",
     "endpoint" : "file://tmp/logs?fileName=messages.log&fileExist=Append&appendChars=\\n",
     "subscriptionAttributes" : {
-      "FilterPolicy" : "{\"status\": [\"not_sent\", \"resend\"], \"amount\": [10.5], \"sold\": [true] }",
+      "FilterPolicy" : "{\"status\": [\"not_sent\", \"resend\"], \"amount\": [{\"numeric\": [\"=\", 10.5]}], \"sold\": [true] }",
       "RawMessageDelivery" : "true"
     }
   }, {
     "arn" : "25da5e63-d5d3-469d-9e0c-e33539948bd1",
     "owner" : "",
-    "topicArn" : "arn:aws:sns:us-east-1:1465414804035:test2",
+    "topicArn" : "arn:aws:sns:us-east-1:0123456789012:test2",
     "protocol" : "file",
     "endpoint" : "file://tmp/logs?fileName=no-attributes.log&fileExist=Append&appendChars=\\n"
   } ],
   "topics" : [ {
-    "arn" : "arn:aws:sns:us-east-1:1465414804035:test1",
+    "arn" : "arn:aws:sns:us-east-1:0123456789012:test1",
     "name" : "test1"
   }, {
-    "arn" : "arn:aws:sns:us-east-1:1465414804035:test2",
+    "arn" : "arn:aws:sns:us-east-1:0123456789012:test2",
     "name" : "test2"
   } ]
 }


### PR DESCRIPTION
# Context
The first pass my exact number matching did not follow the SNS specification according to their [docs](https://docs.aws.amazon.com/sns/latest/dg/numeric-value-matching.html#numeric-exact-matching). This PR corrects this implementation and updates the documenation around supported functionality around subscription attributes.

# Changes
- Correcting numeric filter policy matching for exact matches for message attributes and message body.
- Updating the development documentation.
- Adding documentation for Filter Policy support.
- Correcting the exmaple db.json
- README adjustment.

# Testing and Validation Steps
