### PR TITLE
Add a GET /config Route

### DIFF
--- a/src/main/kotlin/com/jameskbride/localsns/routes/configRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/configRoute.kt
@@ -1,0 +1,19 @@
+package com.jameskbride.localsns.routes
+
+import com.jameskbride.localsns.getDbOutputPath
+import com.jameskbride.localsns.toJsonConfig
+import com.typesafe.config.ConfigFactory
+import io.vertx.core.Vertx
+import io.vertx.ext.web.RoutingContext
+
+val configRoute: (RoutingContext) -> Unit = { ctx: RoutingContext ->
+    val config = ConfigFactory.load()
+    val vertx = Vertx.vertx()
+    val dbPath = getDbOutputPath(config)
+    val dbFile = vertx.fileSystem().readFileBlocking(dbPath)
+    val configuration = toJsonConfig(dbFile)
+    ctx.request().response()
+        .setStatusCode(200)
+        .putHeader("context-type", "application/json")
+        .end(configuration.toString())
+}

--- a/src/main/kotlin/com/jameskbride/localsns/routes/configRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/configRoute.kt
@@ -1,19 +1,47 @@
 package com.jameskbride.localsns.routes
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.jameskbride.localsns.getDbOutputPath
+import com.jameskbride.localsns.getDbPath
+import com.jameskbride.localsns.models.Configuration
 import com.jameskbride.localsns.toJsonConfig
 import com.typesafe.config.ConfigFactory
 import io.vertx.core.Vertx
+import io.vertx.core.json.JsonObject
 import io.vertx.ext.web.RoutingContext
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 val configRoute: (RoutingContext) -> Unit = { ctx: RoutingContext ->
+    val logger: Logger = LogManager.getLogger("configRoute")
     val config = ConfigFactory.load()
     val vertx = Vertx.vertx()
-    val dbPath = getDbOutputPath(config)
-    val dbFile = vertx.fileSystem().readFileBlocking(dbPath)
-    val configuration = toJsonConfig(dbFile)
+    val dbPath = if (vertx.fileSystem().existsBlocking(getDbOutputPath(config))) {
+        getDbOutputPath(config)
+    } else {
+        getDbPath(config)
+    }
+    val configuration = try {
+        val dbFile = vertx.fileSystem().readFileBlocking(dbPath)
+        toJsonConfig(dbFile)
+    } catch(e: Exception) {
+        logger.info("Failed to load configuration: $e")
+        createNewConfig()
+    }
+
     ctx.request().response()
         .setStatusCode(200)
         .putHeader("context-type", "application/json")
         .end(configuration.toString())
+}
+
+fun createNewConfig(): JsonObject {
+    val mapper = jacksonObjectMapper()
+    val configuration = Configuration(
+        version = 1,
+        timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+    )
+    return JsonObject(mapper.writeValueAsString(configuration))
 }

--- a/src/main/kotlin/com/jameskbride/localsns/utils.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/utils.kt
@@ -1,9 +1,13 @@
 package com.jameskbride.localsns
 
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.jameskbride.localsns.models.Subscription
 import com.jameskbride.localsns.models.Topic
 import com.typesafe.config.Config
 import io.vertx.core.Vertx
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.json.JsonObject
+import io.vertx.core.json.jackson.DatabindCodec
 import io.vertx.core.shareddata.LocalMap
 import io.vertx.ext.web.RoutingContext
 import org.apache.logging.log4j.Logger
@@ -19,11 +23,26 @@ fun getDbPath(config: Config): String? =
 fun getDbOutputPath(config: Config): String =
     System.getenv("DB_OUTPUT_PATH") ?: config.getString("db.outputPath")
 
+fun toJsonConfig(configFile: Buffer?) = JsonObject(configFile)
+
 fun getAwsAccountId(config: Config): String =
     System.getenv("AWS_ACCOUNT_ID") ?: config.getString("aws.accountId")
 
 fun getAwsRegion(config: Config): String =
     System.getenv("AWS_DEFAULT_REGION") ?: config.getString("aws.region")
+
+fun getPort(config: Config): Int {
+    val httpPortEnv = System.getenv("HTTP_PORT")
+    val port = if (httpPortEnv !== null) {
+        Integer.parseInt(httpPortEnv)
+    } else {
+        config.getInt("http.port")
+    }
+    return port
+}
+
+fun getHttpInterface(config: Config): String? =
+    System.getenv("HTTP_INTERFACE") ?: config.getString("http.interface")
 
 fun getTopicsMap(vertx: Vertx): LocalMap<String, Topic>? =
     vertx.sharedData().getLocalMap("topics")
@@ -51,3 +70,11 @@ fun getFormAttribute(
     ctx: RoutingContext,
     attribute: String
 ): String? = ctx.request().getFormAttribute(attribute)
+
+fun configureObjectMappers() {
+    val mapper = DatabindCodec.mapper()
+    mapper.registerKotlinModule()
+
+    val prettyMapper = DatabindCodec.prettyMapper()
+    prettyMapper.registerKotlinModule()
+}

--- a/src/main/kotlin/com/jameskbride/localsns/verticles/DatabaseVerticle.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/verticles/DatabaseVerticle.kt
@@ -43,7 +43,7 @@ class DatabaseVerticle: AbstractVerticle() {
                     vertx.eventBus().publish("configChangeComplete", "configChangeComplete")
                 }
                 .onFailure {
-                    logger.error("Unable to config at: $dbPath", it)
+                    logger.error("Unable to save config to: $dbPath", it)
                 }
         }
     }

--- a/src/main/kotlin/com/jameskbride/localsns/verticles/MainVerticle.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/verticles/MainVerticle.kt
@@ -1,5 +1,8 @@
 package com.jameskbride.localsns.verticles
 
+import com.jameskbride.localsns.getHttpInterface
+import com.jameskbride.localsns.getPort
+import com.jameskbride.localsns.routes.configRoute
 import com.jameskbride.localsns.routes.getRoute
 import com.jameskbride.localsns.routes.healthRoute
 import com.typesafe.config.ConfigFactory
@@ -21,13 +24,11 @@ class MainVerticle : AbstractVerticle() {
     router.route().handler(BodyHandler.create())
     router.route("/").handler(getRoute)
     router.route("/health").handler(healthRoute)
+    router.route("/config").handler(configRoute)
 
     val config = ConfigFactory.load()
-    val httpInterface = System.getenv("HTTP_INTERFACE") ?: config.getString("http.interface")
-    val httpPortEnv = System.getenv("HTTP_PORT")
-    val port = if (httpPortEnv !== null) {
-      Integer.parseInt(httpPortEnv)
-    } else { config.getInt("http.port") }
+    val httpInterface = getHttpInterface(config)
+    val port = getPort(config)
 
     val socketAddress = inetSocketAddress(port, httpInterface)
 

--- a/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
@@ -3,6 +3,7 @@ package com.jameskbride.localsns
 import com.jameskbride.localsns.models.Topic
 import com.typesafe.config.ConfigFactory
 import khttp.post
+import khttp.get
 import khttp.responses.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
@@ -21,6 +22,11 @@ open class BaseTest {
             val httpPortEnv = config.getString("http.port")
             return "http://$httpInterface:$httpPortEnv/"
         }
+    }
+
+    fun getCurrentConfig(): Response {
+        val baseUrl = getBaseUrl()
+        return get("$baseUrl/config")
     }
 
     protected fun createValidArn(resourceName: String) =

--- a/src/test/kotlin/com/jameskbride/localsns/ConfigRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/ConfigRouteTest.kt
@@ -1,0 +1,39 @@
+package com.jameskbride.localsns;
+
+import com.jameskbride.localsns.models.Configuration
+import com.jameskbride.localsns.verticles.MainVerticle
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxExtension
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(VertxExtension::class)
+class ConfigRouteTest: BaseTest() {
+
+    @BeforeEach
+    fun setup(vertx:Vertx, testContext:VertxTestContext) {
+        configureObjectMappers()
+        vertx.deployVerticle(MainVerticle(), testContext.succeeding { _ -> testContext.completeNow() })
+    }
+
+    @Test
+    fun `it returns the configuration`(testContext:VertxTestContext) {
+        val response = getCurrentConfig()
+
+        assertEquals(200, response.statusCode)
+        val text = response.text
+        val jsonConfig = io.vertx.core.json.JsonObject(text)
+        assertTrue(jsonConfig.containsKey("topics"))
+        assertTrue(jsonConfig.containsKey("subscriptions"))
+        assertTrue(jsonConfig.containsKey("timestamp"))
+        assertTrue(jsonConfig.containsKey("version"))
+
+        jsonConfig.mapTo(Configuration::class.java)
+
+        testContext.completeNow()
+    }
+}


### PR DESCRIPTION
# Context
This PR adds a convenience endpoint at `GET /config` to retrieve the runtime configuration during development and testing.

# Changes
* Expose `GET /config`.
* Add logging at start-up to indicate the `/health` and `/config` endpoint locations.

# Testing and Validation Steps
1. Start the application via `./gradlew run`.
2. Open http://localhost:9911/config in a browser (or make a `GET /config` request via cURL, POSTman, Insomnia, whatever).
3. ✅ Validate that the current JSON config is returned.
4. Make a change to the config: `aws sns create-topic --endpoint-url http://localhost:9911 --name another-topic`
5. Refresh the browser.
6. ✅ Validate that the config is updated.