### PR TITLE
Capturing the AWS Account ID during SQS Subscribe

### DIFF
--- a/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
@@ -36,8 +36,13 @@ open class BaseTest {
         return "aws2-sqs://$name?accessKey=xxx&secretKey=xxx&region=us-east-1&trustAllCertificates=true&overrideEndpoint=true&uriEndpointOverride=http://localhost:9324/000000000000/$name&messageAttributeNames=first,second"
     }
 
-    fun createHttpSqsEndpoint(name: String): String {
-        return "http://localhost:9324/000000000000/$name"
+    fun createHttpSqsEndpoint(name: String, protocolAndHost: String, port: String? = null): String {
+        val portString = if (port != null) {
+            ":$port"
+        } else {
+            ""
+        }
+        return "$protocolAndHost$portString/000000000000/$name"
     }
 
     fun createCamelHttpEndpoint(uri: String, method: String = "POST"): String {


### PR DESCRIPTION
# Context
This PR is the first step in fixing #25 with ListSubscriptions. When ListSubscriptions is invoked it should display ARNs for SQS subscriptions, however local-sns displays the endpoint instead. In order to fix this behavior we need to capture the AWS Account ID so that we can displays it as part of the ARN value. When an HTTP SQS endpoint subscription is created we need to capture this ID and set it as the `queueOwnerAWSAccountId` Camel parameter (see the [docs](https://camel.apache.org/components/4.4.x/aws2-sqs-component.html#_component_option_queueOwnerAWSAccountId).
 
# Changes
* Updated the Subscribe endpoint to capture the AWS account id for HTTP SQS endpoints, and to set it for the `queueOwnerAWSAccountId` parameter when creating the AWS Camel-compliant endpoint. Example: For the SQS endpoint `https://sqs.us-east-1.amazonaws.com/123456789012/queue1`, `123456789012` is the AWS Account ID. 

# Testing and Validation Steps
