### PR TITLE
Updating Example Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ nbdist/
 db.json
 !example/config/db.json
 example/config/logs
+example/config/ouput

--- a/example/config/elasticmq.conf
+++ b/example/config/elasticmq.conf
@@ -1,9 +1,18 @@
 include classpath("application.conf")
 
 node-address {
+  protocol = http
   host = sqs
+  port = 9324
+  context-path = ""
 }
 
 queues {
   queue1 {}
+}
+
+# Region and accountId which will be included in resource ids
+aws {
+  region = us-east-1
+  accountId = 000000000000
 }

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     depends_on:
     - sqs
   sqs:
-    image: s12v/elasticmq
+    image: softwaremill/elasticmq-native:1.6.5
     ports:
     - "9324:9324"
     volumes:
-    - ./config/elasticmq.conf:/etc/elasticmq/elasticmq.conf
+    - ./config/elasticmq.conf:/opt/elasticmq.conf
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     volumes:
     - ./config/db.json:/etc/sns/db.json
     - ./config/logs:/tmp/logs
+    - ./config/output:/tmp/output
+    environment:
+      - DB_OUTPUT_PATH=/tmp/output/db.json
     depends_on:
     - sqs
   sqs:


### PR DESCRIPTION
# Context
The example configuration wasn't configured correctly to simulate SQS interactions, and wasn't configured to output the example `db.json` file to another location, causing it to update in place.

# Changes
- **Using the DB_OUTPUT_PATH for the example sns configuration.**
- **Updating the example SQS configuration to use softwaremill/elasticmq-native and to set the AWS region and account id.**

# Testing and Validation Steps
