### PR TITLE
Fix main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,5 +19,12 @@ jobs:
           distribution: 'corretto'
           java-version: '11'
 
+      - name: Prepare test environment
+        run: |
+          # Clean up any existing test database files
+          rm -f testDb.json tmp/testDb.json tmp/test-db.json
+          # Ensure tmp directory exists for test outputs
+          mkdir -p tmp
+
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
# Context
The `main` workflow is failing because we didn't apply the same test clean-up that we did for the `pull_request` workflow.

# Changes
* Creating a tmp directory and clearing any test db.json files out

# Testing and Validation Steps