### PR TITLE
Make SignatureVersion a String

### DIFF
--- a/src/main/kotlin/com/jameskbride/localsns/models/SnsMessage.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/SnsMessage.kt
@@ -6,7 +6,7 @@ data class SnsMessage(
     @SerializedName("Message") val message:String,
     @SerializedName("MessageId") val messageId:String,
     @SerializedName("Signature") val signature:String,
-    @SerializedName("SignatureVersion") val signatureVersion: Int,
+    @SerializedName("SignatureVersion") val signatureVersion: String,
     @SerializedName("SigningCertUrl") val signingCertUrl:String,
     @SerializedName("Subject") val subject: String? = null,
     @SerializedName("Timestamp") val timestamp: String,

--- a/src/main/kotlin/com/jameskbride/localsns/topics/publish.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/topics/publish.kt
@@ -282,7 +282,7 @@ private fun createSnsMessage(
         message,
         UUID.randomUUID().toString(),
         "SIGNATURE",
-        1,
+        "1",
         "http://signing-cert-url",
         null,
         formattedTimestamp,

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.jameskbride.localsns
 
 import com.google.gson.Gson
 import com.google.gson.JsonArray
+import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.jameskbride.localsns.models.MessageAttribute
 import com.jameskbride.localsns.models.Topic
@@ -16,6 +17,7 @@ import io.vertx.junit5.VertxExtension
 import io.vertx.junit5.VertxTestContext
 import org.elasticmq.server.ElasticMQServer
 import org.elasticmq.server.config.ElasticMQServerConfig
+import org.json.JSONString
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
@@ -625,6 +627,7 @@ class PublishRouteIntegrationTest: BaseTest() {
                 val gson = Gson()
                 val requestBody = body.toString("UTF-8")
                 val jsonBody = gson.fromJson(requestBody, JsonObject::class.java)
+                assertTrue(jsonBody.get("SignatureVersion").isJsonPrimitive && jsonBody.get("SignatureVersion").asJsonPrimitive.isString)
                 assertEquals(message, jsonBody.get("Message").asString)
                 testContext.completeNow()
             }


### PR DESCRIPTION
# Context
This PR partially addresses https://github.com/jameskbride/local-sns/issues/37 by converting SignatureVersion to a String as per the AWS documentation and usage.
# Changes
* Updating `SnsMessage.signatureVersion` to a String.

# Testing and Validation Steps
1. Create a small HTTP server that accepts a `POST` and logs payloads.
2. Create a new `http` subscription that points the HTTP server.
3. Publish a message to the topic for the subscription.
4. Validate that the `SignatureVersion` is now a String value instead of an integer.
