### PR TITLE
Implement UnsubscribeURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Configuration can be set via environment variables:
 - `HTTP_PORT` - tcp port, default: `9911`
 - `AWS_DEFAULT_REGION` - AWS region, default: `us-east-1`
 - `AWS_ACCOUNT_ID` - AWS Account ID, default: `123456789012`
+- `LOCAL_SNS_HOSTNAME` - Hostname to use for URL callbacks
 
 ## Supported integrations
 

--- a/src/main/kotlin/com/jameskbride/localsns/api/PublishApiRoutes.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/api/PublishApiRoutes.kt
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonSyntaxException
+import com.jameskbride.localsns.getCachedConfig
 import com.jameskbride.localsns.getTopicsMap
 import com.jameskbride.localsns.models.MessageAttribute
 import com.jameskbride.localsns.models.Topic
@@ -165,18 +166,21 @@ val publishMessageApiRoute: (RoutingContext) -> Unit = lambda@{ ctx ->
 
         val camelContext = DefaultCamelContext()
         camelContext.start()
+        val cachedConfig = getCachedConfig(ctx.vertx())
 
         if (request.messageStructure == "json") {
             publishJsonStructure(
                 publishRequest,
                 camelContext.createProducerTemplate(),
-                ctx.vertx()
+                ctx.vertx(),
+                cachedConfig,
             )
         } else {
             publishBasicMessageToTopic(
                 publishRequest,
                 camelContext.createProducerTemplate(),
-                ctx.vertx()
+                ctx.vertx(),
+                cachedConfig,
             )
         }
 

--- a/src/main/kotlin/com/jameskbride/localsns/models/NotificationSnsMessage.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/NotificationSnsMessage.kt
@@ -2,7 +2,7 @@ package com.jameskbride.localsns.models
 
 import com.google.gson.annotations.SerializedName
 
-data class SnsMessage(
+data class NotificationSnsMessage(
     @SerializedName("Message") val message:String,
     @SerializedName("MessageId") val messageId:String,
     @SerializedName("Signature") val signature:String,
@@ -12,5 +12,5 @@ data class SnsMessage(
     @SerializedName("Timestamp") val timestamp: String,
     @SerializedName("TopicArn") val topicArn: String,
     @SerializedName("Type") val type: String = "Notification",
-    @SerializedName("UnsubscribeUrl") val unsubscribeUrl: String? = null,
+    @SerializedName("UnsubscribeURL") val unsubscribeUrl: String,
 )

--- a/src/main/kotlin/com/jameskbride/localsns/models/lambdaEvents.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/lambdaEvents.kt
@@ -6,7 +6,7 @@ data class LambdaRecord(
     @SerializedName("EventSource") val eventSource:String,
     @SerializedName("EventSubscriptionArn") val eventSubscriptionArn:String,
     @SerializedName("EventVersion") val eventVersion:Double,
-    @SerializedName("Sns") val message: SnsMessage,
+    @SerializedName("Sns") val message: NotificationSnsMessage,
 )
 data class LambdaEvent(
     @SerializedName("Records") val records:List<LambdaRecord> = listOf()

--- a/src/main/kotlin/com/jameskbride/localsns/routes/routes.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/routes.kt
@@ -26,7 +26,7 @@ val routeMapping = mapOf(
 val getRoute: (RoutingContext) -> Unit = { ctx: RoutingContext ->
     val logger: Logger = LogManager.getLogger("routes")
     try {
-        val action = ctx.request().getFormAttribute("Action")
+        val action = ctx.request().getFormAttribute("Action") ?: ctx.request().getParam("Action")
         val route = routeMapping.getOrDefault(action, rootRoute)
         route(ctx)
     } catch(ex: Exception) {

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/unsubscribeRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/unsubscribeRoute.kt
@@ -1,7 +1,7 @@
 package com.jameskbride.localsns.routes.subscriptions
 
-import com.jameskbride.localsns.NOT_FOUND
 import com.jameskbride.localsns.getFormAttribute
+import com.jameskbride.localsns.getRequestParam
 import com.jameskbride.localsns.getSubscriptionsMap
 import com.jameskbride.localsns.logAndReturnError
 import com.jameskbride.localsns.models.Subscription
@@ -15,7 +15,7 @@ val unsubscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
     val logger: Logger = LogManager.getLogger("unsubscribeRoute")
     val vertx = ctx.vertx()
     val subscriptions = getSubscriptionsMap(vertx)
-    val subscriptionArn = getFormAttribute(ctx, "SubscriptionArn")
+    val subscriptionArn = getFormAttribute(ctx, "SubscriptionArn") ?: getRequestParam(ctx, "SubscriptionArn")
     if (subscriptionArn == null) {
         logAndReturnError(ctx, logger, "SubscriptionArn is missing")
         return@route

--- a/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/unsubscribeRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/subscriptions/unsubscribeRoute.kt
@@ -31,8 +31,8 @@ val unsubscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         .firstOrNull { it.arn == subscriptionArn }
 
     if (subscription == null) {
-        val errorMessage = "Subscription not found: $subscriptionArn"
-        logAndReturnError(ctx, logger, errorMessage, NOT_FOUND, 404)
+        //Idempotency for multiple unsubscribes for the same subscription arn
+        renderSuccess(ctx)
         return@route
     }
 
@@ -41,11 +41,15 @@ val unsubscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         .filter { it.arn != subscriptionArn }
     subscriptions[subscription.topicArn] = updatedSubscriptions
     vertx.eventBus().publish("configChange", "configChange")
-    ctx.request().response()
-        .putHeader("context-type", "text/xml")
-        .setStatusCode(200)
-        .end(
-            """
+    renderSuccess(ctx)
+}
+
+private fun renderSuccess(ctx: RoutingContext) {
+  ctx.request().response()
+    .putHeader("context-type", "text/xml")
+    .setStatusCode(200)
+    .end(
+      """
               <UnsubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
                 <ResponseMetadata>
                   <RequestId>
@@ -54,5 +58,5 @@ val unsubscribeRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
                 </ResponseMetadata>
               </UnsubscribeResponse>
             """.trimIndent()
-        )
+    )
 }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishBatchRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishBatchRoute.kt
@@ -64,6 +64,7 @@ val publishBatchRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         return@route
     }
 
+    val cachedConfig = getCachedConfig(vertx).toMap()
     val camelContext = DefaultCamelContext()
     camelContext.start()
     val gson = Gson()
@@ -84,7 +85,8 @@ val publishBatchRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
                     publishJsonStructure(
                         publishRequest,
                         camelContext.createProducerTemplate(),
-                        vertx
+                        vertx,
+                        cachedConfig,
                     )
                 }
                 else -> {
@@ -92,6 +94,7 @@ val publishBatchRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
                         publishRequest,
                         camelContext.createProducerTemplate(),
                         vertx,
+                        cachedConfig,
                     )
                 }
             }
@@ -100,6 +103,7 @@ val publishBatchRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
                 publishRequest,
                 camelContext.createProducerTemplate(),
                 vertx,
+                cachedConfig,
             )
         }
     }

--- a/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/routes/topics/publishRoute.kt
@@ -3,6 +3,7 @@ package com.jameskbride.localsns.routes.topics
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.jameskbride.localsns.NOT_FOUND
+import com.jameskbride.localsns.getCachedConfig
 import com.jameskbride.localsns.getFormAttribute
 import com.jameskbride.localsns.getTopicsMap
 import com.jameskbride.localsns.logAndReturnError
@@ -70,7 +71,7 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
         messageAttributes = messageAttributes,
         topicArn = topicArn
     )
-
+    val cachedConfig = getCachedConfig(vertx)
     if (messageStructure != null) {
          when (messageStructure) {
             "json" -> {
@@ -82,7 +83,8 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
                 publishJsonStructure(
                     publishRequest,
                     camelContext.createProducerTemplate(),
-                    vertx
+                    vertx,
+                    cachedConfig
                 )
             }
             else -> {
@@ -90,6 +92,7 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
                     publishRequest,
                     camelContext.createProducerTemplate(),
                     vertx,
+                    cachedConfig
                 )
             }
         }
@@ -98,6 +101,7 @@ val publishRoute: (RoutingContext) -> Unit = route@{ ctx: RoutingContext ->
             publishRequest,
             camelContext.createProducerTemplate(),
             vertx,
+            cachedConfig
         )
     }
 

--- a/src/main/kotlin/com/jameskbride/localsns/topics/publish.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/topics/publish.kt
@@ -1,6 +1,7 @@
 package com.jameskbride.localsns.topics
 
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import com.jameskbride.localsns.BASE_URL
 import com.jameskbride.localsns.getSubscriptionsMap
@@ -44,7 +45,7 @@ fun publishJsonStructure(
         try {
             logger.info("Publishing message to topic with json structure {}", publishRequest.topicArn)
             val subscriptions = getTopicSubscriptions(publishRequest.topicArn, vertx)
-            val gson = Gson()
+            val gson = GsonBuilder().disableHtmlEscaping().create()
             val messages = gson.fromJson(publishRequest.message, JsonObject::class.java)
             subscriptions.map { subscription ->
                 val messageToPublish: String = if (messages.has(subscription.protocol)) {
@@ -183,7 +184,7 @@ private fun matchesMessageAttributesFilterPolicy(
 
 private fun matchesMessageBodyFilterPolicy(subscription: Subscription, message:String): Boolean {
     val filterPolicySubscriptionAttribute = subscription.subscriptionAttributes[FILTER_POLICY]
-    val gson = Gson()
+    val gson = GsonBuilder().disableHtmlEscaping().create()
     val messageJson = gson.fromJson(message, JsonObject::class.java)
     val matched = filterPolicySubscriptionAttribute?.let { MessageBodyFilterPolicy(it).matches(messageJson) } ?: true
     return matched
@@ -211,7 +212,7 @@ private fun publishAllowingRawMessage(
     } else {
         val timestamp = LocalDateTime.now()
         val snsMessage = createSnsMessage(subscription, message, timestamp, cachedConfig)
-        val gson = Gson()
+        val gson = GsonBuilder().disableHtmlEscaping().create()
         gson.toJson(snsMessage)
     }
     return publishToCamel(subscription.decodedEndpointUrl(), messageToPublish, headers, producer)
@@ -226,7 +227,7 @@ private fun publishToLambda(
 ): CompletableFuture<Any>? {
     val timestamp = LocalDateTime.now()
     val snsMessage = createSnsMessage(subscription, message, timestamp, cachedConfig)
-    val gson = Gson()
+    val gson = GsonBuilder().disableHtmlEscaping().create()
     val record = LambdaRecord("aws:sns", subscription.arn, 1.0, snsMessage)
     val event = LambdaEvent(listOf(record))
     val messageToPublish = gson.toJson(event)
@@ -247,7 +248,7 @@ private fun publishToHttp(
 ): CompletableFuture<Any>? {
     val timestamp = LocalDateTime.now()
     val snsMessage = createSnsMessage(subscription, message, timestamp, cachedConfig)
-    val gson = Gson()
+    val gson = GsonBuilder().disableHtmlEscaping().create()
     val httpHeaders = if (subscription.isRawMessageDelivery()) {
         headers + mapOf("x-amz-sns-rawdelivery" to "true")
     } else {
@@ -290,7 +291,7 @@ private fun createSnsMessage(
 ): NotificationSnsMessage {
     val formattedTimestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(timestamp)
     val baseUrl = cachedConfig.get(BASE_URL)
-    val unsubscribeUrl = "${baseUrl}?Action=Unsubscribe&SubscriptionArn${subscription.arn}"
+    val unsubscribeUrl = "${baseUrl}?Action=Unsubscribe&SubscriptionArn=${subscription.arn}"
     return NotificationSnsMessage(
         message,
         UUID.randomUUID().toString(),

--- a/src/main/kotlin/com/jameskbride/localsns/topics/publish.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/topics/publish.kt
@@ -2,6 +2,7 @@ package com.jameskbride.localsns.topics
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.jameskbride.localsns.BASE_URL
 import com.jameskbride.localsns.getSubscriptionsMap
 import com.jameskbride.localsns.models.*
 import com.jameskbride.localsns.models.SubscriptionAttribute.Companion.FILTER_POLICY
@@ -10,6 +11,7 @@ import io.vertx.core.Vertx
 import org.apache.camel.ProducerTemplate
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.net.URLEncoder
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -36,6 +38,7 @@ fun publishJsonStructure(
     publishRequest: PublishRequest,
     producerTemplate: ProducerTemplate,
     vertx: Vertx,
+    cachedConfig: Map<String, String>
 ) {
     vertx.executeBlocking<Any>({ ->
         try {
@@ -54,7 +57,8 @@ fun publishJsonStructure(
                     subscription,
                     messageToPublish,
                     publishRequest.messageAttributes,
-                    producerTemplate
+                    producerTemplate,
+                    cachedConfig
                 )
                     ?.exceptionally { logger.error("Error publishing to subscription: ${subscription.arn}", it) }
             }
@@ -74,13 +78,14 @@ fun publishBasicMessageToTopic(
     publishRequest: PublishRequest,
     producerTemplate: ProducerTemplate,
     vertx: Vertx,
+    cachedConfig: Map<String, String>
 ) {
     vertx.executeBlocking({ ->
         try {
             val subscriptions = getTopicSubscriptions(publishRequest.topicArn, vertx)
             logger.info("Publishing to topic: ${publishRequest.topicArn}")
             subscriptions.map { subscription ->
-                publishToSubscription(subscription, publishRequest.message, publishRequest.messageAttributes, producerTemplate)
+                publishToSubscription(subscription, publishRequest.message, publishRequest.messageAttributes, producerTemplate, cachedConfig)
                     ?.exceptionally { logger.error("An error occurred when publishing to: ${subscription.endpoint}", it) }
             }
             Future.succeededFuture<Any>()
@@ -99,7 +104,8 @@ private fun publishToSubscription(
     subscription: Subscription,
     message: String,
     messageAttributes: Map<String, MessageAttribute> = mapOf(),
-    producer: ProducerTemplate
+    producer: ProducerTemplate,
+    cachedConfig: Map<String, String>
 ): CompletableFuture<Any>? {
     val matchesFilterPolicy = matchesFilterPolicy(subscription, message, messageAttributes)
 
@@ -118,17 +124,17 @@ private fun publishToSubscription(
     return when (subscription.protocol) {
         "lambda" -> {
             logger.info("Publishing to Lambda subscription: ${subscription.arn}")
-            publishToLambda(subscription, message, headers, producer)
+            publishToLambda(subscription, message, headers, producer, cachedConfig)
         }
 
         "http" -> {
             logger.info("Publishing to HTTP subscription: ${subscription.arn}")
-            publishToHttp(subscription, message, headers, producer)
+            publishToHttp(subscription, message, headers, producer, cachedConfig)
         }
 
         "https" -> {
             logger.info("Publishing to HTTPS subscription: ${subscription.arn}")
-            publishToHttp(subscription, message, headers, producer)
+            publishToHttp(subscription, message, headers, producer, cachedConfig)
         }
 
         "slack" -> {
@@ -138,12 +144,12 @@ private fun publishToSubscription(
 
         "sqs" -> {
             logger.info("Publishing to SQS subscription: ${subscription.arn}")
-            publishToSqs(subscription, message, headers, producer)
+            publishToSqs(subscription, message, headers, producer, cachedConfig)
         }
 
         else -> {
             logger.info("Publishing to subscription: ${subscription.arn}")
-            publishAllowingRawMessage(subscription, message, headers, producer)
+            publishAllowingRawMessage(subscription, message, headers, producer, cachedConfig)
         }
     }
 }
@@ -187,22 +193,24 @@ private fun publishToSqs(
     subscription: Subscription,
     message: String,
     headers: Map<String, String>,
-    producer: ProducerTemplate
+    producer: ProducerTemplate,
+    cachedConfig: Map<String, String>
 ): CompletableFuture<Any>? {
-    return publishAllowingRawMessage(subscription, message, headers, producer)
+    return publishAllowingRawMessage(subscription, message, headers, producer, cachedConfig)
 }
 
 private fun publishAllowingRawMessage(
     subscription: Subscription,
     message: String,
     headers: Map<String, String>,
-    producer: ProducerTemplate
+    producer: ProducerTemplate,
+    cachedConfig: Map<String, String>
 ): CompletableFuture<Any>? {
     val messageToPublish = if (subscription.isRawMessageDelivery()) {
         message
     } else {
         val timestamp = LocalDateTime.now()
-        val snsMessage = createSnsMessage(subscription, message, timestamp)
+        val snsMessage = createSnsMessage(subscription, message, timestamp, cachedConfig)
         val gson = Gson()
         gson.toJson(snsMessage)
     }
@@ -213,10 +221,11 @@ private fun publishToLambda(
     subscription: Subscription,
     message: String,
     headers: Map<String, String>,
-    producer: ProducerTemplate
+    producer: ProducerTemplate,
+    cachedConfig: Map<String, String>
 ): CompletableFuture<Any>? {
     val timestamp = LocalDateTime.now()
-    val snsMessage = createSnsMessage(subscription, message, timestamp)
+    val snsMessage = createSnsMessage(subscription, message, timestamp, cachedConfig)
     val gson = Gson()
     val record = LambdaRecord("aws:sns", subscription.arn, 1.0, snsMessage)
     val event = LambdaEvent(listOf(record))
@@ -233,10 +242,11 @@ private fun publishToHttp(
     subscription: Subscription,
     message: String,
     headers: Map<String, String>,
-    producer: ProducerTemplate
+    producer: ProducerTemplate,
+    cachedConfig: Map<String, String>
 ): CompletableFuture<Any>? {
     val timestamp = LocalDateTime.now()
-    val snsMessage = createSnsMessage(subscription, message, timestamp)
+    val snsMessage = createSnsMessage(subscription, message, timestamp, cachedConfig)
     val gson = Gson()
     val httpHeaders = if (subscription.isRawMessageDelivery()) {
         headers + mapOf("x-amz-sns-rawdelivery" to "true")
@@ -275,10 +285,13 @@ private fun publishToCamel(
 private fun createSnsMessage(
     subscription: Subscription,
     message: String,
-    timestamp: LocalDateTime?
-): SnsMessage {
+    timestamp: LocalDateTime?,
+    cachedConfig: Map<String, String>
+): NotificationSnsMessage {
     val formattedTimestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(timestamp)
-    return SnsMessage(
+    val baseUrl = cachedConfig.get(BASE_URL)
+    val unsubscribeUrl = "${baseUrl}?Action=Unsubscribe&SubscriptionArn${subscription.arn}"
+    return NotificationSnsMessage(
         message,
         UUID.randomUUID().toString(),
         "SIGNATURE",
@@ -287,5 +300,7 @@ private fun createSnsMessage(
         null,
         formattedTimestamp,
         subscription.topicArn,
+        "Notification",
+        unsubscribeUrl,
     )
 }

--- a/src/main/kotlin/com/jameskbride/localsns/utils.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/utils.kt
@@ -21,6 +21,7 @@ const val EMPTY_BATCH_REQUEST = "EmptyBatchRequest"
 const val TOO_MANY_ENTRIES_IN_BATCH_REQUEST = "TooManyEntriesInBatchRequest"
 const val BATCH_ENTRY_IDS_NOT_DISTINCT = "BatchEntryIdNotDistinct"
 const val INVALID_BATCH_ENTRY_ID = "InvalidBatchEntryId"
+const val BASE_URL = "baseUrl"
 
 fun getDbPath(config: Config): String? =
     System.getenv("DB_PATH") ?: config.getString("db.path")
@@ -64,6 +65,10 @@ fun getTopicsMap(vertx: Vertx): LocalMap<String, Topic>? =
 
 fun getSubscriptionsMap(vertx: Vertx): LocalMap<String, List<Subscription>>? =
     vertx.sharedData().getLocalMap("subscriptions")
+
+fun getCachedConfig(vertx: Vertx): LocalMap<String, String> {
+  return vertx.sharedData().getLocalMap("cachedConfig")
+}
 
 fun logAndReturnError(ctx: RoutingContext, logger: Logger, errorMessage: String, code: String = INVALID_PARAMETER, statusCode: Int = 400) {
     logger.error(errorMessage)

--- a/src/main/kotlin/com/jameskbride/localsns/utils.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/utils.kt
@@ -91,6 +91,9 @@ fun getFormAttribute(
     attribute: String
 ): String? = ctx.request().getFormAttribute(attribute)
 
+fun getRequestParam(ctx: RoutingContext, attribute: String): String? =
+  ctx.request().getParam(attribute)
+
 fun configureObjectMappers() {
     val mapper = DatabindCodec.mapper()
     mapper.registerKotlinModule()

--- a/src/main/kotlin/com/jameskbride/localsns/verticles/MainVerticle.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/verticles/MainVerticle.kt
@@ -1,9 +1,11 @@
 package com.jameskbride.localsns.verticles
 
+import com.jameskbride.localsns.BASE_URL
 import com.jameskbride.localsns.api.config.*
 import com.jameskbride.localsns.api.publishMessageApiRoute
 import com.jameskbride.localsns.api.subscriptions.*
 import com.jameskbride.localsns.api.topics.*
+import com.jameskbride.localsns.getCachedConfig
 import com.jameskbride.localsns.getHttpInterface
 import com.jameskbride.localsns.getPort
 import com.jameskbride.localsns.routes.configRoute
@@ -12,12 +14,14 @@ import com.jameskbride.localsns.routes.healthRoute
 import com.typesafe.config.ConfigFactory
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Promise
+import io.vertx.core.Vertx
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.net.SocketAddress.inetSocketAddress
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.handler.BodyHandler
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.net.InetAddress
 
 class MainVerticle : AbstractVerticle() {
 
@@ -61,8 +65,12 @@ class MainVerticle : AbstractVerticle() {
     val httpInterface = getHttpInterface(config)
     val port = getPort(config)
 
-    val socketAddress = inetSocketAddress(port, httpInterface)
+    val hostname = InetAddress.getLocalHost().hostName
+    val baseUrl = "http://$hostname:$port"
+    val cachedConfig = getCachedConfig(vertx)
+    cachedConfig[BASE_URL] = baseUrl
 
+    val socketAddress = inetSocketAddress(port, httpInterface)
     val server = vertx.createHttpServer(HttpServerOptions().setMaxFormAttributeSize(-1))
     server.requestHandler(router).listen(socketAddress) { http ->
       if (http.succeeded()) {

--- a/src/main/kotlin/com/jameskbride/localsns/verticles/MainVerticle.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/verticles/MainVerticle.kt
@@ -65,7 +65,7 @@ class MainVerticle : AbstractVerticle() {
     val httpInterface = getHttpInterface(config)
     val port = getPort(config)
 
-    val hostname = InetAddress.getLocalHost().hostName
+    val hostname = System.getenv("LOCAL_SNS_HOSTNAME") ?: httpInterface
     val baseUrl = "http://$hostname:$port"
     val cachedConfig = getCachedConfig(vertx)
     cachedConfig[BASE_URL] = baseUrl

--- a/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/BaseTest.kt
@@ -16,6 +16,11 @@ open class BaseTest {
         return post(baseUrl, data = payload)
     }
 
+    protected fun postQueryParams(data: Map<String, String>): Response {
+      val baseUrl = getBaseUrl()
+      return post(baseUrl, params = data)
+    }
+
     /**
      * Resets the configuration to a clean state for testing
      */
@@ -146,7 +151,7 @@ open class BaseTest {
         return postFormData(data)
     }
 
-    fun unsubscribe(subscriptionArn: String? = null): Response {
+    fun unsubscribe(subscriptionArn: String? = null, useFormData:Boolean = true): Response {
         val data = mutableMapOf(
             "Action" to "Unsubscribe"
         )
@@ -155,7 +160,11 @@ open class BaseTest {
             data["SubscriptionArn"] = subscriptionArn
         }
 
-        return postFormData(data)
+        return if (useFormData) {
+          postFormData(data)
+        } else {
+          postQueryParams(data)
+        }
     }
 
     fun setSubscriptionAttributes(subscriptionArn: String?, attributeName: String?, attributeValue: String?): Response {

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -2,7 +2,6 @@ package com.jameskbride.localsns
 
 import com.google.gson.Gson
 import com.google.gson.JsonArray
-import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.jameskbride.localsns.models.MessageAttribute
 import com.jameskbride.localsns.models.Topic
@@ -17,8 +16,8 @@ import io.vertx.junit5.VertxExtension
 import io.vertx.junit5.VertxTestContext
 import org.elasticmq.server.ElasticMQServer
 import org.elasticmq.server.config.ElasticMQServerConfig
-import org.json.JSONString
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -31,11 +30,7 @@ import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.SqsClient
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
-import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest
-import software.amazon.awssdk.services.sqs.model.Message
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import software.amazon.awssdk.services.sqs.model.*
 import java.io.Serializable
 import java.net.URI
 import java.util.*
@@ -132,7 +127,7 @@ class PublishRouteIntegrationTest: BaseTest() {
                 val requestBody = it.body()
                 val gson = Gson()
                 val jsonBody = gson.fromJson(requestBody, JsonObject::class.java)
-                message == jsonBody.get("Message").asString
+                message == jsonBody.get("Message").asString && !jsonBody.get("UnsubscribeURL").isJsonNull
             })
             messages.forEach {
                 sqsClient.deleteMessage(DeleteMessageRequest.builder().receiptHandle(it.receiptHandle()).build())
@@ -629,6 +624,7 @@ class PublishRouteIntegrationTest: BaseTest() {
                 val jsonBody = gson.fromJson(requestBody, JsonObject::class.java)
                 assertTrue(jsonBody.get("SignatureVersion").isJsonPrimitive && jsonBody.get("SignatureVersion").asJsonPrimitive.isString)
                 assertEquals(message, jsonBody.get("Message").asString)
+                assertFalse(jsonBody.get("UnsubscribeURL").isJsonNull)
                 testContext.completeNow()
             }
 

--- a/src/test/kotlin/com/jameskbride/localsns/UnsubscribeRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/UnsubscribeRouteTest.kt
@@ -73,6 +73,19 @@ class UnsubscribeRouteTest: BaseTest() {
     }
 
     @Test
+    fun `it allow request params to be used successfully`(testContext: VertxTestContext) {
+      val topic = createTopicModel("topic1")
+      val subscriptionResponse = subscribe(topic.arn, createCamelSqsEndpoint("endpoint"), "sqs")
+      val subscriptionArn = getSubscriptionArnFromResponse(subscriptionResponse)
+
+      val response = unsubscribe(subscriptionArn, useFormData = false)
+
+      Assertions.assertEquals(200, response.statusCode)
+
+      testContext.completeNow()
+    }
+
+    @Test
     fun `it indicates a db change`(vertx: Vertx, testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val subscriptionResponse = subscribe(topic.arn, createCamelSqsEndpoint("endpoint"), "sqs")

--- a/src/test/kotlin/com/jameskbride/localsns/UnsubscribeRouteTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/UnsubscribeRouteTest.kt
@@ -28,10 +28,10 @@ class UnsubscribeRouteTest: BaseTest() {
     }
 
     @Test
-    fun `it returns an error when subscription arn does not exist`(testContext: VertxTestContext) {
+    fun `it returns success when subscription arn does not exist for idempotency`(testContext: VertxTestContext) {
         val response = unsubscribe(createValidArn("queue1"))
 
-        Assertions.assertEquals(404, response.statusCode)
+        Assertions.assertEquals(200, response.statusCode)
 
         testContext.completeNow()
     }


### PR DESCRIPTION
# Context
This addresses https://github.com/jameskbride/local-sns/issues/37 by implementing the UnsubscribeURL in the SNS message.

# Changes
- Unsubscribing is idempotent.
- Setting the UnsubscribeURL on the SNS message.
- Adding support for setting a hostname.
- Correcting message formatting.
- Allow request params for routing and unsubscribe.

# Testing and Validation Steps
1. Send an SNS message.
2. Validate that the UnsubscribeURL is included in the SNS message.
3. Set the `LOCAL_SNS_HOSTNAME` environment variable.
4. Validate that the `UnsubscribeURL` uses the `LOCAL_SNS_HOSTNAME`
