### PR TITLE
Subscription Filters - Adding $or predicate support

### DIFF
--- a/JSON_API.md
+++ b/JSON_API.md
@@ -130,7 +130,7 @@
   "endpoint": "http://example.com/webhook",
   "attributes": {
     "RawMessageDelivery": "true",
-    "FilterPolicy": "{\"key\": \"value\"}"
+    "FilterPolicy": "{\"eventType\": [\"order_created\"]}"
   }
 }
 ```
@@ -147,11 +147,30 @@
 {
   "attributes": {
     "RawMessageDelivery": "false",
-    "FilterPolicy": "{\"updated\": \"policy\"}"
+    "FilterPolicy": "{\"status\": [\"updated\"]}"
   }
 }
 ```
 - **Response**: Updated subscription object
+
+### FilterPolicy Notes and Examples
+
+`FilterPolicy` is stored as a JSON string in subscription attributes.
+
+Basic exact-match example:
+```json
+"FilterPolicy": "{\"eventType\": [\"order_created\"], \"priority\": [\"high\"]}"
+```
+
+`$or` operator example:
+```json
+"FilterPolicy": "{\"source\": [\"aws.cloudwatch\"], \"$or\": [{\"metricName\": [\"CPUUtilization\"]}, {\"namespace\": [\"AWS/EC2\"]}]}"
+```
+
+Notes:
+- Filter values must be arrays (for example `{"type": ["order"]}` instead of `{"type": "order"}`).
+- `$or` should be an array with at least two object branches.
+- Overall filter support is still limited to the supported matcher types documented in the main README.
 
 ### Delete Subscription
 - **DELETE** `/api/subscriptions/:arn`
@@ -177,7 +196,7 @@
   "endpoint": "http://example.com/webhook",
   "attributes": {
     "RawMessageDelivery": "true",
-    "FilterPolicy": "{\"key\": \"value\"}"
+    "FilterPolicy": "{\"eventType\": [\"order_created\"]}"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -100,8 +100,24 @@ docker-compose up
   | [Numeric Value Range match](https://docs.aws.amazon.com/sns/latest/dg/numeric-value-matching.html#numeric-value-range-matching)                                                                 | No                                                                                           |
   | [And Logic](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-payload-constraints)                                               | Yes                                                                                          |
   | [Or Logic](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html#subscription-filter-policy-payload-constraints)                                                | Yes                                                                                          |
-  | [Or Operator](https://docs.aws.amazon.com/sns/latest/dg/and-or-logic.html#or-operator)                                                                                                          | No                                                                                           |
+  | [Or Operator](https://docs.aws.amazon.com/sns/latest/dg/and-or-logic.html#or-operator)                                                                                                          | Yes                                                                                            |
   | [Key Matching](https://docs.aws.amazon.com/sns/latest/dg/attribute-key-matching.html)                                                                                                           | No                                                                                           |
+
+  Example `FilterPolicy` with `$or` for `MessageAttributes` scope:
+  ```json
+  {
+    "source": ["aws.cloudwatch"],
+    "$or": [
+      {"metricName": ["CPUUtilization"]},
+      {"namespace": ["AWS/EC2"]}
+    ]
+  }
+  ```
+
+  Additional notes:
+  - Filter policy values must be arrays (for example, `{"type": ["order"]}`, not `{"type": "order"}`).
+  - For explicit `$or` handling, use an array with at least two object branches.
+  - local-sns supports the `$or` operator itself, but overall FilterPolicy support is still limited by the unsupported matcher types listed in the table above.
 
 ### Additional Endpoints
 * `GET /config` - Returns the current configuration of the local-sns instance.

--- a/src/main/kotlin/com/jameskbride/localsns/models/MessageAttributeFilterPolicy.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/MessageAttributeFilterPolicy.kt
@@ -9,33 +9,78 @@ import com.jameskbride.localsns.subscriptions.validateNumericMatcher
 class MessageAttributeFilterPolicy(filterPolicy: String) {
     private val gson = Gson()
     private val filterPolicyJsonObject = gson.fromJson(filterPolicy, JsonObject::class.java)
+    private val reservedOrOperatorKeywords = setOf(
+        "numeric",
+        "prefix",
+        "anything-but",
+        "exists",
+        "cidr",
+        "suffix",
+        "equals-ignore-case",
+        "wildcard"
+    )
 
     fun matches(messageAttributes: Map<String, MessageAttribute>): Boolean {
-        val allKeysPresent = filterPolicyJsonObject.asMap().all { messageAttributes.containsKey(it.key) }
-        if (!allKeysPresent) {
+        return matchesPolicy(filterPolicyJsonObject, messageAttributes)
+    }
+
+    private fun matchesPolicy(policyJsonObject: JsonObject, messageAttributes: Map<String, MessageAttribute>): Boolean {
+        val andPolicyEntries = policyJsonObject.asMap().filterKeys { it != "\$or" }
+        val andEntriesMatch = andPolicyEntries.all {
+            matchesSingleAttributePolicy(it.key, it.value, messageAttributes)
+        }
+        if (!andEntriesMatch) {
             return false
         }
 
-        val attributePolicies = filterPolicyJsonObject.asMap().map {
-            val attributePolicy = when(it.value) {
-                is JsonArray -> {
-                    val firstElement = (it.value.asJsonArray).firstOrNull()
-                    val elementType = getElementType(firstElement)
-                    when (elementType) {
-                        "String" -> StringAttributeFilterPolicy(it.key, (it.value.asJsonArray).map { value -> value.asString })
-                        "Object" -> NumberAttributeFilterPolicy(it.key, firstElement?.asJsonObject)
-                        else -> throw IllegalArgumentException("Unsupported filter policy value type")
-                    }
-                }
-                else -> throw IllegalArgumentException("Unsupported filter policy value type")
+        val orPolicyValue = policyJsonObject.get("\$or") ?: return true
+        if (!isRecognizedOrOperator(orPolicyValue)) {
+            return matchesSingleAttributePolicy("\$or", orPolicyValue, messageAttributes)
+        }
+
+        return orPolicyValue.asJsonArray.any {
+            matchesPolicy(it.asJsonObject, messageAttributes)
+        }
+    }
+
+    private fun isRecognizedOrOperator(orPolicyValue: Any?): Boolean {
+        if (orPolicyValue !is JsonArray || orPolicyValue.size() < 2) {
+            return false
+        }
+
+        return orPolicyValue.all { branch ->
+            if (!branch.isJsonObject) {
+                return@all false
             }
 
-            it.key to attributePolicy
-        }.toMap()
+            val branchFields = branch.asJsonObject.keySet()
+            branchFields.none { reservedOrOperatorKeywords.contains(it) }
+        }
+    }
 
-        return attributePolicies.all {
-            val messageAttribute = messageAttributes[it.key]
-            it.value.matches(messageAttribute!!)
+    private fun matchesSingleAttributePolicy(
+        key: String,
+        policyValue: Any?,
+        messageAttributes: Map<String, MessageAttribute>
+    ): Boolean {
+        val messageAttribute = messageAttributes[key] ?: return false
+        val attributePolicy = buildAttributePolicy(key, policyValue)
+        return attributePolicy.matches(messageAttribute)
+    }
+
+    private fun buildAttributePolicy(key: String, policyValue: Any?): AttributeFilterPolicy {
+        return when (policyValue) {
+            is JsonArray -> {
+                val firstElement = policyValue.firstOrNull()
+                val elementType = getElementType(firstElement)
+                when (elementType) {
+                    "String" -> StringAttributeFilterPolicy(key, policyValue.map { value -> value.asString })
+                    "Object" -> NumberAttributeFilterPolicy(key, firstElement?.asJsonObject)
+                    else -> throw IllegalArgumentException("Unsupported filter policy value type")
+                }
+            }
+
+            else -> throw IllegalArgumentException("Unsupported filter policy value type")
         }
     }
 }

--- a/src/main/kotlin/com/jameskbride/localsns/models/MessageBodyFilterPolicy.kt
+++ b/src/main/kotlin/com/jameskbride/localsns/models/MessageBodyFilterPolicy.kt
@@ -8,48 +8,98 @@ import com.jameskbride.localsns.subscriptions.validateNumericMatcher
 class MessageBodyFilterPolicy(filterPolicy: String) {
     private val gson = Gson()
     private val filterPolicyJsonObject = gson.fromJson(filterPolicy, JsonObject::class.java)
+    private val reservedOrOperatorKeywords = setOf(
+        "numeric",
+        "prefix",
+        "anything-but",
+        "exists",
+        "cidr",
+        "suffix",
+        "equals-ignore-case",
+        "wildcard"
+    )
 
     fun matches(messageJsonObject: JsonObject): Boolean {
-        val allKeysPresent = filterPolicyJsonObject.asMap().all { messageJsonObject.has(it.key) }
-        if (!allKeysPresent) {
+        return matchesPolicy(filterPolicyJsonObject, messageJsonObject)
+    }
+
+    private fun matchesPolicy(policyJsonObject: JsonObject, messageJsonObject: JsonObject): Boolean {
+        val andPolicyEntries = policyJsonObject.asMap().filterKeys { it != "\$or" }
+        val andEntriesMatch = andPolicyEntries.all {
+            matchesSingleAttributePolicy(it.key, it.value, messageJsonObject)
+        }
+        if (!andEntriesMatch) {
             return false
         }
 
-        val attributePolicies = filterPolicyJsonObject.asMap().map {
-            val attributeType = getElementType(messageJsonObject.get(it.key))
-            if (!listOf("String", "Number", "Boolean", "null").contains(attributeType)) {
-                it.key to NonMatchingMessageBodyFilterPolicy()
-            } else {
-                val filterValue = it.value.asJsonArray
-                val firstElement = filterValue.asList().firstOrNull()
+        val orPolicyValue = policyJsonObject.get("\$or") ?: return true
+        if (!isRecognizedOrOperator(orPolicyValue)) {
+            return matchesSingleAttributePolicy("\$or", orPolicyValue, messageJsonObject)
+        }
+
+        return orPolicyValue.asJsonArray.any {
+            matchesPolicy(it.asJsonObject, messageJsonObject)
+        }
+    }
+
+    private fun isRecognizedOrOperator(orPolicyValue: Any?): Boolean {
+        if (orPolicyValue !is com.google.gson.JsonArray || orPolicyValue.size() < 2) {
+            return false
+        }
+
+        return orPolicyValue.all { branch ->
+            if (!branch.isJsonObject) {
+                return@all false
+            }
+
+            val branchFields = branch.asJsonObject.keySet()
+            branchFields.none { reservedOrOperatorKeywords.contains(it) }
+        }
+    }
+
+    private fun matchesSingleAttributePolicy(key: String, policyValue: Any?, messageJsonObject: JsonObject): Boolean {
+        val attributeType = getElementType(messageJsonObject.get(key))
+        if (!listOf("String", "Number", "Boolean", "null").contains(attributeType)) {
+            return false
+        }
+
+        val attributePolicy = buildAttributePolicy(key, policyValue)
+        return attributePolicy.matches(messageJsonObject)
+    }
+
+    private fun buildAttributePolicy(key: String, policyValue: Any?): MessageFilterPolicy {
+        return when (policyValue) {
+            is com.google.gson.JsonArray -> {
+                val firstElement = policyValue.asList().firstOrNull()
                 val elementType = getElementType(firstElement)
-                val attributePolicy = when (elementType) {
+                when (elementType) {
                     "String" -> {
-                        StringMessageBodyFilterPolicy(it.key, filterValue.map { value -> value.asString })
+                        StringMessageBodyFilterPolicy(key, policyValue.map { value -> value.asString })
                     }
+
                     "Boolean" -> {
                         val booleanValue = firstElement?.asBoolean
-                        BooleanMessageBodyFilterPolicy(it.key, listOf(booleanValue!!))
+                        BooleanMessageBodyFilterPolicy(key, listOf(booleanValue!!))
                     }
+
                     "Object" -> {
                         val numericMatcher = firstElement?.asJsonObject
-                        NumberMessageBodyFilterPolicy(it.key, numericMatcher!!)
+                        NumberMessageBodyFilterPolicy(key, numericMatcher!!)
                     }
+
                     "null" -> {
-                        NullMessageBodyFilterPolicy(it.key)
+                        NullMessageBodyFilterPolicy(key)
                     }
+
                     else -> {
                         throw IllegalArgumentException("Unsupported filter policy value type")
                     }
                 }
-
-                it.key to attributePolicy
             }
 
-        }.toMap()
-
-        return attributePolicies.all { policy ->
-            policy.value.matches(messageJsonObject)
+            else -> {
+                throw IllegalArgumentException("Unsupported filter policy value type")
+            }
         }
     }
 }

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -642,6 +642,127 @@ class PublishRouteIntegrationTest: BaseTest() {
     }
 
     @Test
+    fun `FilterPolicy MessageBody - it does publish when one $or branch matches`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = UUID.randomUUID().toString()
+        val endpoint = createQueue(queueName)
+        val filterPolicy = """
+            {
+              "source": ["aws.cloudwatch"],
+              "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to filterPolicy,
+                "FilterPolicyScope" to "MessageBody",
+            )
+        )
+        val message = """
+            {"source": "aws.cloudwatch", "namespace": "AWS/EC2"}
+        """.trimIndent()
+
+        val request = publishRequest(topic, message)
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("source", "namespace")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
+    fun `FilterPolicy MessageBody - it does not publish when no $or branches match`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = UUID.randomUUID().toString()
+        val endpoint = createQueue(queueName)
+        val filterPolicy = """
+            {
+              "source": ["aws.cloudwatch"],
+              "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to filterPolicy,
+                "FilterPolicyScope" to "MessageBody",
+            )
+        )
+        val message = """
+            {"source": "aws.cloudwatch", "metricName": "ReadLatency"}
+        """.trimIndent()
+
+        val request = publishRequest(topic, message)
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("source", "metricName")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.failNow("Message was not filtered")
+            } else {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
+    fun `FilterPolicy MessageBody - it does not publish when top-level key is missing even if $or branch matches`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = UUID.randomUUID().toString()
+        val endpoint = createQueue(queueName)
+        val filterPolicy = """
+            {
+              "source": ["aws.cloudwatch"],
+              "${'$'}or": [
+                {"namespace": ["AWS/EC2"]},
+                {"metricName": ["CPUUtilization"]}
+              ]
+            }
+        """.trimIndent()
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to filterPolicy,
+                "FilterPolicyScope" to "MessageBody",
+            )
+        )
+        val message = """
+            {"namespace": "AWS/EC2"}
+        """.trimIndent()
+
+        val request = publishRequest(topic, message)
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("namespace")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.failNow("Message was not filtered")
+            } else {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
     fun `it can publish raw messages to sqs`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val queueName = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/PublishRouteIntegrationTest.kt
@@ -322,6 +322,135 @@ class PublishRouteIntegrationTest: BaseTest() {
     }
 
     @Test
+    fun `FilterPolicy MessageAttributes - it does publish when one $or branch matches`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = UUID.randomUUID().toString()
+        val endpoint = createQueue(queueName)
+        val filterPolicyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+                            "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to filterPolicyJson
+            )
+        )
+
+        val request = publishRequest(
+            topic,
+            "Hello, SNS!",
+            messageAttributes = listOf(
+                MessageAttribute("source", "aws.cloudwatch"),
+                MessageAttribute("namespace", "AWS/EC2")
+            )
+        )
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("source", "namespace")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
+    fun `FilterPolicy MessageAttributes - it does not publish when no $or branches match`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = UUID.randomUUID().toString()
+        val endpoint = createQueue(queueName)
+        val filterPolicyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+                            "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to filterPolicyJson
+            )
+        )
+
+        val request = publishRequest(
+            topic,
+            "Hello, SNS!",
+            messageAttributes = listOf(
+                MessageAttribute("source", "aws.cloudwatch"),
+                MessageAttribute("metricName", "ReadLatency")
+            )
+        )
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("source", "metricName")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.failNow("Message was not filtered")
+            } else {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
+    fun `FilterPolicy MessageAttributes - it does not publish when top-level key is missing even if $or branch matches`(testContext: VertxTestContext) {
+        val topic = createTopicModel("topic1")
+        val queueName = UUID.randomUUID().toString()
+        val endpoint = createQueue(queueName)
+        val filterPolicyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+                            "${'$'}or": [
+                {"namespace": ["AWS/EC2"]},
+                {"metricName": ["CPUUtilization"]}
+              ]
+            }
+        """.trimIndent()
+        subscribe(
+            topic.arn,
+            endpoint,
+            "sqs",
+            mapOf(
+                "FilterPolicy" to filterPolicyJson
+            )
+        )
+
+        val request = publishRequest(
+            topic,
+            "Hello, SNS!",
+            messageAttributes = listOf(
+                MessageAttribute("namespace", "AWS/EC2")
+            )
+        )
+        snsClient.publish(request)
+
+        val queueUrl = createQueueUrl(queueName)
+        startReceivingMessages(queueUrl, setOf("namespace")) { response ->
+            val messages = response.messages()
+            if (messages.isNotEmpty()) {
+                testContext.failNow("Message was not filtered")
+            } else {
+                testContext.completeNow()
+            }
+        }
+    }
+
+    @Test
     fun `FilterPolicy MessageBody - it does not publish when message body attributes do not match`(testContext: VertxTestContext) {
         val topic = createTopicModel("topic1")
         val queueName = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/jameskbride/localsns/models/MessageAttributeFilterPolicyTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/models/MessageAttributeFilterPolicyTest.kt
@@ -241,4 +241,115 @@ class MessageAttributeFilterPolicyTest {
         val result = messageAttributeFilterPolicy.matches(messageAttributes)
         assert(!result) { "Expected basic String filter policy to not match message attributes" }
     }
- }
+
+    @Test
+    fun `it matches when one $or branch matches`() {
+        val filterPolicyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+                            "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+
+        val messageAttributeFilterPolicy = MessageAttributeFilterPolicy(filterPolicyJson)
+        val messageAttributes = mapOf(
+            "source" to MessageAttribute(name="source", value="aws.cloudwatch"),
+            "namespace" to MessageAttribute(name="namespace", value="AWS/EC2")
+        )
+
+        val result = messageAttributeFilterPolicy.matches(messageAttributes)
+        assert(result) { "Expected filter policy with \$or to match when one branch matches" }
+    }
+
+    @Test
+    fun `it does not match when no $or branch matches`() {
+        val filterPolicyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+                            "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+
+        val messageAttributeFilterPolicy = MessageAttributeFilterPolicy(filterPolicyJson)
+        val messageAttributes = mapOf(
+            "source" to MessageAttribute(name="source", value="aws.cloudwatch"),
+            "metricName" to MessageAttribute(name="metricName", value="ReadLatency")
+        )
+
+        val result = messageAttributeFilterPolicy.matches(messageAttributes)
+        assert(!result) { "Expected filter policy with \$or to not match when no branches match" }
+    }
+
+    @Test
+    fun `it does not match when top-level key matches but $or branch does not`() {
+        val filterPolicyJson = """
+            {
+              "status": ["not_sent"],
+                            "${'$'}or": [
+                {"amount": [{"numeric": ["=", 10.5]}]},
+                {"region": ["us-east-1"]}
+              ]
+            }
+        """.trimIndent()
+
+        val messageAttributeFilterPolicy = MessageAttributeFilterPolicy(filterPolicyJson)
+        val messageAttributes = mapOf(
+            "status" to MessageAttribute(name="status", value="not_sent"),
+            "amount" to MessageAttribute(name="amount", value="11.0", dataType="Number")
+        )
+
+        val result = messageAttributeFilterPolicy.matches(messageAttributes)
+        assert(!result) { "Expected top-level AND with \$or to fail when no branch matches" }
+    }
+
+    @Test
+    fun `it treats invalid $or with one branch as a normal attribute key`() {
+        val filterPolicyJson = """
+            {
+              "${'$'}or": ["branch-value"]
+            }
+        """.trimIndent()
+
+        val messageAttributeFilterPolicy = MessageAttributeFilterPolicy(filterPolicyJson)
+
+        val matches = messageAttributeFilterPolicy.matches(
+            mapOf("\$or" to MessageAttribute(name="\$or", value="branch-value"))
+        )
+        val doesNotMatch = messageAttributeFilterPolicy.matches(
+            mapOf("\$or" to MessageAttribute(name="\$or", value="other"))
+        )
+
+        assert(matches) { "Expected invalid \$or operator shape to be treated as normal key" }
+        assert(!doesNotMatch) { "Expected normal key matching behavior for invalid \$or operator shape" }
+    }
+
+    @Test
+    fun `it treats $or with reserved keyword branch fields as a normal attribute key`() {
+        val filterPolicyJson = """
+            {
+                            "${'$'}or": [
+                                {"numeric": ["=", 1]},
+                {"metricName": ["CPUUtilization"]}
+              ]
+            }
+        """.trimIndent()
+
+        val messageAttributeFilterPolicy = MessageAttributeFilterPolicy(filterPolicyJson)
+
+        val matches = messageAttributeFilterPolicy.matches(
+            mapOf("\$or" to MessageAttribute(name="\$or", value="1", dataType="Number"))
+        )
+        val doesNotMatch = messageAttributeFilterPolicy.matches(
+            mapOf("\$or" to MessageAttribute(name="\$or", value="2", dataType="Number"))
+        )
+
+        assert(matches) { "Expected reserved branch field names to disable \$or operator parsing" }
+        assert(!doesNotMatch) { "Expected fallback matching to honor normal key semantics" }
+    }
+}

--- a/src/test/kotlin/com/jameskbride/localsns/models/MessageBodyFilterPolicyTest.kt
+++ b/src/test/kotlin/com/jameskbride/localsns/models/MessageBodyFilterPolicyTest.kt
@@ -153,4 +153,109 @@ class MessageBodyFilterPolicyTest {
         """.trimIndent()
         assert(!filterPolicy.matches(gson.fromJson(message, JsonObject::class.java)))
     }
+
+    @Test
+    fun `it matches when one $or branch matches`() {
+        val policyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+              "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+
+        val filterPolicy = MessageBodyFilterPolicy(policyJson)
+
+        val message = """
+            {"source": "aws.cloudwatch", "namespace": "AWS/EC2"}
+        """.trimIndent()
+        assert(filterPolicy.matches(gson.fromJson(message, JsonObject::class.java)))
+    }
+
+    @Test
+    fun `it does not match when no $or branch matches`() {
+        val policyJson = """
+            {
+              "source": ["aws.cloudwatch"],
+              "${'$'}or": [
+                {"metricName": ["CPUUtilization"]},
+                {"namespace": ["AWS/EC2"]}
+              ]
+            }
+        """.trimIndent()
+
+        val filterPolicy = MessageBodyFilterPolicy(policyJson)
+
+        val message = """
+            {"source": "aws.cloudwatch", "metricName": "ReadLatency"}
+        """.trimIndent()
+        assert(!filterPolicy.matches(gson.fromJson(message, JsonObject::class.java)))
+    }
+
+    @Test
+    fun `it does not match when top-level key matches but $or branch does not`() {
+        val policyJson = """
+            {
+              "status": ["not_sent"],
+              "${'$'}or": [
+                {"amount": [{"numeric": ["=", 10.5]}]},
+                {"region": ["us-east-1"]}
+              ]
+            }
+        """.trimIndent()
+
+        val filterPolicy = MessageBodyFilterPolicy(policyJson)
+
+        val message = """
+            {"status": "not_sent", "amount": 11.0}
+        """.trimIndent()
+        assert(!filterPolicy.matches(gson.fromJson(message, JsonObject::class.java)))
+    }
+
+    @Test
+    fun `it treats invalid $or with one branch as a normal message body key`() {
+        val policyJson = """
+            {
+              "${'$'}or": ["branch-value"]
+            }
+        """.trimIndent()
+
+        val filterPolicy = MessageBodyFilterPolicy(policyJson)
+
+        val matchingMessage = """
+            {"${'$'}or": "branch-value"}
+        """.trimIndent()
+        val nonMatchingMessage = """
+            {"${'$'}or": "other"}
+        """.trimIndent()
+
+        assert(filterPolicy.matches(gson.fromJson(matchingMessage, JsonObject::class.java)))
+        assert(!filterPolicy.matches(gson.fromJson(nonMatchingMessage, JsonObject::class.java)))
+    }
+
+    @Test
+    fun `it treats $or with reserved keyword branch fields as a normal message body key`() {
+        val policyJson = """
+            {
+              "${'$'}or": [
+                {"numeric": ["=", 1]},
+                {"metricName": ["CPUUtilization"]}
+              ]
+            }
+        """.trimIndent()
+
+        val filterPolicy = MessageBodyFilterPolicy(policyJson)
+
+        val matchingMessage = """
+            {"${'$'}or": 1}
+        """.trimIndent()
+        val nonMatchingMessage = """
+            {"${'$'}or": 2}
+        """.trimIndent()
+
+        assert(filterPolicy.matches(gson.fromJson(matchingMessage, JsonObject::class.java)))
+        assert(!filterPolicy.matches(gson.fromJson(nonMatchingMessage, JsonObject::class.java)))
+    }
 }


### PR DESCRIPTION
# Context
Adding `$or` predicate support for subscription filters. See https://docs.aws.amazon.com/sns/latest/dg/and-or-logic.html
# Changes
- **Adding  support to MessageAttribute filter.**
- **Adding support for  predicate to MessageBody filter.**

# Testing and Validation Steps
